### PR TITLE
Add WebKit clone-and-select() manual test

### DIFF
--- a/lib/org/chromium/webidl/LocalGitIDLFileDAO.js
+++ b/lib/org/chromium/webidl/LocalGitIDLFileDAO.js
@@ -186,13 +186,15 @@ foam.CLASS({
             `"${this.GIT_PATH}" rev-parse HEAD`,
             {cwd: this.localRepositoryPath})
                 .toString().trim();
-        var basePath = this.localRepositoryPath +
-            (this.sparsePath ? `/${this.sparsePath}` : '');
+        var basePath = '.' + (this.sparsePath ? `/${this.sparsePath}` : '');
         var execStr = `"${this.FIND_PATH}" "${basePath}" -type f -path "*.idl"`;
         for (var i = 0; i < this.findExcludePatterns.length; i++) {
           execStr += ` -not -path "${this.findExcludePatterns[i]}"`;
         }
-        this.childProcess_.exec(execStr, this.onPaths);
+        this.childProcess_.exec(
+            execStr,
+            {cwd: this.localRepositoryPath},
+            this.onPaths);
       },
     },
     {
@@ -210,14 +212,15 @@ foam.CLASS({
         var promises = [];
         var onFileReady = this.onFileReady;
         var readFile = this.fs_.readFile;
-        // Size of prefix: "/path/to/repo/" (including trailing slash).
-        var prefixLen = this.localRepositoryPath.length + 1;
+        var basePath = this.localRepositoryPath;
         for (var i = 0; i < paths.length; i++) {
-          // Path relative to repository root.
-          var path = paths[i].substr(prefixLen);
+          // Path relative to repository root; drop "./" from "find . [...]"
+          // output.
+          var path = paths[i].substr(2);
           // Bind "onFileReady" with file path and promise callbacks.
           promises.push(new Promise(function(resolve, reject) {
-            readFile(paths[i], onFileReady.bind(this, path, resolve, reject));
+            readFile(`${basePath}/${paths[i]}`,
+                     onFileReady.bind(this, path, resolve, reject));
           }));
         }
         // Wait for all "onFileReady" to put to delegate; then notify readiness.

--- a/test/node/blinkIDLFileDAO-manual.js
+++ b/test/node/blinkIDLFileDAO-manual.js
@@ -12,7 +12,7 @@ var config = {
   findExcludePatterns: ['*/testing/*', '*/bindings/tests/*', '*/mojo/*'],
 };
 config.idlFileContentsFactory = function(path, contents) {
-  // Classes are injected by integrationLocalGitTest.
+  // Classes are injected by manualLocalGitTest.
   return config.IDLFileContents.create({
     metadata: config.GitilesIDLFile.create({
       repository: this.respositoryURL,

--- a/test/node/manualLocalGitTest-helper.js
+++ b/test/node/manualLocalGitTest-helper.js
@@ -4,9 +4,7 @@
 'use strict';
 
 global.manualLocalGitTest = function(data) {
-  console.log('Setting up test');
   describe(data.description, function() {
-    console.log('Describe');
     var execSync = require('child_process').execSync;
     var originalTimeout;
 
@@ -43,6 +41,7 @@ global.manualLocalGitTest = function(data) {
         }),
       }).select(foam.lookup('foam.mlang.sink.Count').create()).then(
         function(sink) {
+          console.log(sink.value, 'IDL files found');
           expect(sink.value).toBeGreaterThan(0);
           done();
         }, done.fail);

--- a/test/node/webKitIDLFileDAO-manual.js
+++ b/test/node/webKitIDLFileDAO-manual.js
@@ -12,7 +12,7 @@ var config = {
   findExcludePatterns: ['*/testing/*', '*/test/*'],
 };
 config.idlFileContentsFactory = function(path, contents) {
-  // Classes are injected by integrationLocalGitTest.
+  // Classes are injected by manualLocalGitTest.
   return config.IDLFileContents.create({
     metadata: config.GithubIDLFile.create({
       repository: this.respositoryURL,

--- a/test/node/webKitIDLFileDAO-manual.js
+++ b/test/node/webKitIDLFileDAO-manual.js
@@ -1,0 +1,26 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+var githubBaseURL = 'https://github.com/WebKit/webkit';
+var config = {
+  description: 'WebKit IDL file DAO manual test',
+  repositoryURL: 'https://github.com/WebKit/webkit.git',
+  localRepositoryPath: require('path').resolve(__dirname, '../data/WebKit/git'),
+  sparsePath: 'Source',
+  findExcludePatterns: ['*/testing/*', '*/test/*'],
+};
+config.idlFileContentsFactory = function(path, contents) {
+  // Classes are injected by integrationLocalGitTest.
+  return config.IDLFileContents.create({
+    metadata: config.GithubIDLFile.create({
+      repository: this.respositoryURL,
+      githubBaseURL: githubBaseURL,
+      revision: this.commit,
+      path: path,
+    }),
+    contents: contents,
+  });
+};
+global.manualLocalGitTest(config);


### PR DESCRIPTION
Includes bug fix: LocalGitIDLFileDAO `find` invocation shouldn't match against complete path, just repository path.