### PR TITLE
Test and implement: Gecko parser

### DIFF
--- a/config/files.js
+++ b/config/files.js
@@ -94,6 +94,7 @@
     `lib${sep}org${sep}chromium${sep}webidl${sep}BaseParser.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}Parser.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}WebKitParser.js`,
+    `lib${sep}org${sep}chromium${sep}webidl${sep}GeckoParser.js`,
 
     // IDL file stuff
     `lib${sep}org${sep}chromium${sep}webidl${sep}IDLFile.js`,

--- a/lib/org/chromium/webidl/GeckoParser.js
+++ b/lib/org/chromium/webidl/GeckoParser.js
@@ -1,0 +1,84 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  package: 'org.chromium.webidl',
+  name: 'GeckoParser',
+  extends: 'org.chromium.webidl.Parser',
+
+  requires: [
+    'org.chromium.webidl.Parser',
+    'org.chromium.webidl.parsers.TokenParsers',
+  ],
+
+  properties: [
+    {
+      name: 'separator',
+      factory: function() {
+        return foam.Function.withArgs(
+            function(plus0, alt, seq1, repeat0, notChars, seq) {
+              return repeat0(alt(
+                  // Whitespace.
+                  alt(' ', '\t', '\n', '\r', '\f'),
+                  // Single-line comment.
+                  seq(
+                      '//',
+                      repeat0(notChars('\r\n')), alt('\r\n', '\n')),
+                  // Multi-line comment.
+                  seq1(
+                      1,
+                      '/*',
+                      repeat0(alt(notChars('*'), seq('*', notChars('\/')))),
+                      '*\/'),
+                  // C-style preprocessor directives.
+                  seq('#', repeat0(notChars('\r\n')))));
+            },
+            this.Parsers.create(),
+            this);
+      },
+    },
+  ],
+
+  methods: [
+    function symbolsFactory() {
+      return Object.assign(this.SUPER(), foam.Function.withArgs(
+          function(alt, sym, tseq, tplus, trepeat) {
+            return {
+              // Definitions may include interface forward declarations.
+              Definitions: trepeat(alt(
+                  sym('InterfaceFwdDecl'),
+                  tseq(sym('ExtendedAttributeList'), sym('Definition')))),
+              InterfaceFwdDecl: tseq('interface', sym('identifier'), ';'),
+              // InterfaceMembers may include "jsonifier;" member.
+              InterfaceMembers: trepeat(alt(
+                  sym('Jsonifier'),
+                  tseq(sym('ExtendedAttributeList'), sym('InterfaceMember')))),
+              Jsonifier: tseq('jsonifier', ';'),
+            };
+          },
+          this.TokenParsers.create({separator: this.separator}),
+          this));
+    },
+    function actionsFactory() {
+      var parser = this;
+      var superActions = this.SUPER();
+      // For Definitions and InterfaceMembers:
+      // Filter out unnecessary fwd decls and "jsonifier;"s, then apply base
+      // class action.
+      return Object.assign(superActions, {
+        Definitions: function(v) {
+          return superActions.Definitions.call(
+              this, v.filter(function(def) { return def !== null; }));
+        },
+        InterfaceFwdDecl: function() { return null; },
+        InterfaceMembers: function(v) {
+          return superActions.InterfaceMembers.call(
+              this, v.filter(function(m) { return m !== null; }));
+        },
+        Jsonifier: function() { return null; },
+      });
+    },
+  ],
+});

--- a/lib/org/chromium/webidl/GeckoParser.js
+++ b/lib/org/chromium/webidl/GeckoParser.js
@@ -64,17 +64,19 @@ foam.CLASS({
     function actionsFactory() {
       var parser = this;
       var superActions = this.SUPER();
+      var Definitions = superActions.Definitions;
+      var InterfaceMembers = superActions.InterfaceMembers;
       // For Definitions and InterfaceMembers:
       // Filter out unnecessary fwd decls and "jsonifier;"s, then apply base
       // class action.
       return Object.assign(superActions, {
         Definitions: function(v) {
-          return superActions.Definitions.call(
+          return Definitions.call(
               this, v.filter(function(def) { return def !== null; }));
         },
         InterfaceFwdDecl: function() { return null; },
         InterfaceMembers: function(v) {
-          return superActions.InterfaceMembers.call(
+          return InterfaceMembers.call(
               this, v.filter(function(m) { return m !== null; }));
         },
         Jsonifier: function() { return null; },

--- a/test/any/parsing/GeckoParser-test.js
+++ b/test/any/parsing/GeckoParser-test.js
@@ -1,0 +1,43 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('GeckoParser', function() {
+  var Parser;
+  var GeckoParser;
+  beforeEach(function() {
+    Parser = foam.lookup('org.chromium.webidl.Parser');
+    GeckoParser = foam.lookup('org.chromium.webidl.GeckoParser');
+  });
+
+  function parse(str, opt_production) {
+    var p = GeckoParser.create().parseString(str, opt_production);
+    expect(p.pos).toBe(str.length);
+    return p;
+  }
+
+  it('should parse interface forward declaration as null', function() {
+    var p = parse('interface Frobinator;', 'InterfaceFwdDecl');
+    expect(p.value).toBeNull();
+  });
+  it('should parse "jsonifier;" as null', function() {
+    var p = parse('jsonifier;', 'Jsonifier');
+    expect(p.value).toBeNull();
+  });
+  it('should skip C-style preprocessor directives', function() {
+    var p = parse(`
+        #ifndef FOO
+        interface Location {
+          #if BAR
+          [SomeCustomExtendedAttribute]
+          #endif
+          stringifier attribute USVString href;
+
+          jsonifier;
+        };
+        #endif
+    `);
+    expect(p.value).toBeDefined();
+  });
+});


### PR DESCRIPTION
Parser for Gecko Web IDL dialect. Customizations:

- C-preprocessor-style directives
- `interface Foo;` forward declarations
- `jsonifier;` custom interface member