### PR TITLE
Parser fixes to get cmp(parse(s), parse(stringify(parse(s)))) === 0

### DIFF
--- a/lib/org/chromium/webidl/Parser.js
+++ b/lib/org/chromium/webidl/Parser.js
@@ -531,12 +531,12 @@ foam.CLASS({
           if (v === ';') return parser.Stringifier.create();
           return parser.Attribute.isInstance(v) ?
               parser.Stringifier.create({attribute: v}) :
-          parser.Stringifier.create({operation: v});
+              parser.Stringifier.create({operation: v});
         },
         StaticMember: function(v) {
           return parser.Attribute.isInstance(v) ?
               parser.StaticMember.create({attribute: v}) :
-          parser.StaticMember.create({operation: v});
+              parser.StaticMember.create({operation: v});
         },
         Iterable: function(v) {
           return parser.Iterable.create({type: v[2], valueType: v[3]});

--- a/lib/org/chromium/webidl/Parser.js
+++ b/lib/org/chromium/webidl/Parser.js
@@ -525,7 +525,7 @@ foam.CLASS({
           if (v === ';') return parser.Serializer.create();
           return parser.Operation.isInstance(v) ?
               parser.Serializer.create({operation: v}) :
-          parser.Serializer.create({pattern: v});
+              parser.Serializer.create({pattern: v});
         },
         Stringifier: function(v) {
           if (v === ';') return parser.Stringifier.create();
@@ -559,9 +559,6 @@ foam.CLASS({
         SerializerRestOperation: function(v) {
           if (v[0] !== null) v[1].returnType = v[0];
           return v[1];
-        },
-        SerializerRestEmpty: function(v) {
-          return null;
         },
         SerializationPattern: function(v) {
           // Special case: String "getter" is the whole map/array inner
@@ -629,7 +626,7 @@ foam.CLASS({
           // Add params to existing NonUnionType.
           if (v[0].params) v[0].params = v[0].params.concat(v[2]);
           else v[0].params = v[2];
-          if (v[4] !== null) v[0].params = v[0].params.concat(v[4]);
+          if (v[4] !== null) v[0].suffixes = v[4];
           return v[0];
         },
         SimpleType: function(v) {
@@ -642,13 +639,22 @@ foam.CLASS({
         },
         TypeSuffixes: function(v) {
           if (v === null) return null;
+          // <1> (Nullable|Array)
+          // <2> left-out-optional
+          // ==> [ <1> ]
           if (v[1] === null) return [v[0]];
-          if (v[0] === parser.TypeSuffix.NULLABLE)
+          if (v[0] === parser.TypeSuffix.NULLABLE) {
+            // <1> Nullable
+            // <2> Array
+            // <3> TypeSuffixes
+            // ==> [ <1>, <2> ].concat(<3>)
             return [v[0], v[1][0]].concat(v[1][1]);
-          else
+          } else {
+            // <1> Array
+            // <2> TypeSuffixes
+            // ==> [ <1> ].concat(<2>)
             return [v[0]].concat(v[1]);
-          if (v[1]) return v[0].concat(v[1]);
-          return [v[0]];
+          }
         },
         Nullable: function(v) {
           return parser.TypeSuffix.NULLABLE;

--- a/lib/org/chromium/webidl/ast/Attribute.js
+++ b/lib/org/chromium/webidl/ast/Attribute.js
@@ -15,7 +15,7 @@ foam.CLASS({
 
   methods: [
     function outputWebIDL(o) {
-      if (this.isInherited) o.outputStrs('inherited ');
+      if (this.isInherited) o.outputStrs('inherit ');
       if (this.isReadOnly) o.outputStrs('readonly ');
       o.outputStrs('attribute ').outputObj(this.type).outputStrs(' ')
           .outputObj(this.name).outputStrs(';');

--- a/lib/org/chromium/webidl/ast/ExtendedAttribute.js
+++ b/lib/org/chromium/webidl/ast/ExtendedAttribute.js
@@ -6,17 +6,4 @@
 foam.CLASS({
   package: 'org.chromium.webidl.ast',
   name: 'ExtendedAttribute',
-
-  methods: [
-    function compareTo(other) {
-      if (!this.cls_.isInstance(other)) return this.SUPER(other);
-
-      var left = this.name ? this.name.literal : '';
-      var right = other.name ? other.name.literal : '';
-      if (left < right) return -1;
-      else if (left > right) return 1;
-
-      return this.SUPER(other);
-    },
-  ],
 });

--- a/lib/org/chromium/webidl/ast/MapLike.js
+++ b/lib/org/chromium/webidl/ast/MapLike.js
@@ -22,7 +22,7 @@ foam.CLASS({
 
   methods: [
     function outputWebIDL(o) {
-      if (this.isInherited) o.outputStrs('inherited ');
+      if (this.isInherited) o.outputStrs('inherit ');
       if (this.isReadOnly) o.outputStrs('readonly ');
       o.outputStrs('maplike')
           .forEach([this.type, this.valueType], '<', '>', ',').outputStrs(';');

--- a/lib/org/chromium/webidl/ast/Named.js
+++ b/lib/org/chromium/webidl/ast/Named.js
@@ -14,18 +14,4 @@ foam.CLASS({
       name: 'name',
     },
   ],
-
-  methods: [
-    function compareTo(other) {
-      if ((!this.cls_.isInstance(other)) || (!this.name) || (!other.name))
-        return this.SUPER(other);
-
-      var left = this.name.literal;
-      var right = other.name.literal;
-      if (left < right) return -1;
-      else if (left > right) return 1;
-
-      return this.SUPER(other);
-    },
-  ],
 });

--- a/lib/org/chromium/webidl/ast/SetLike.js
+++ b/lib/org/chromium/webidl/ast/SetLike.js
@@ -14,7 +14,7 @@ foam.CLASS({
 
   methods: [
     function outputWebIDL(o) {
-      if (this.isInherited) o.outputStrs('inherited ');
+      if (this.isInherited) o.outputStrs('inherit ');
       if (this.isReadOnly) o.outputStrs('readonly ');
       o.outputStrs('setlike<').outputObj(this.type).outputStrs('>;');
     },

--- a/lib/org/chromium/webidl/ast/StaticMember.js
+++ b/lib/org/chromium/webidl/ast/StaticMember.js
@@ -22,14 +22,6 @@ foam.CLASS({
   ],
 
   methods: [
-    function compareTo(other) {
-      if (!this.cls_.isInstance(other)) return this.SUPER(other);
-
-      return foam.util.compare(
-        this.attribute || this.operation,
-        other.attribute || other.operation
-      );
-    },
     function outputWebIDL(o) {
       o.outputStrs('static ');
       if (this.attribute)

--- a/test/any/parsing/cmp-integration.js
+++ b/test/any/parsing/cmp-integration.js
@@ -40,7 +40,7 @@ describe('Comparing parses', function() {
         foam.util.compare(firstFragment, secondFragment),
         'parse(' + name + ')[' + i + '] == parse(stringify(parse(' + name +
           ')[' + i + ']))'
-      );
+      ).toBe(0);
     }
   }
 


### PR DESCRIPTION
(0) Enable comparison tests
(1) Drop inconsistent custom compareTo()
(2) Fix up parse+stringify of 'inherit', serializer, type suffixes