### PR TITLE
Moving Spec URLs from HTMLFileContents to IDLFileContents

### DIFF
--- a/lib/org/chromium/webidl/HTMLFileContents.js
+++ b/lib/org/chromium/webidl/HTMLFileContents.js
@@ -26,11 +26,5 @@ foam.CLASS({
       class: 'String',
       name: 'contents',
     },
-    {
-      class: 'Array',
-      of: 'String',
-      documentation: 'Any array of files referencing the URL of this file.',
-      name: 'references',
-    },
   ],
 });

--- a/lib/org/chromium/webidl/IDLFileContents.js
+++ b/lib/org/chromium/webidl/IDLFileContents.js
@@ -11,7 +11,6 @@ foam.CLASS({
 
   requires: [
     'foam.core.Property',
-    'foam.net.HTTPrequest',
   ],
 
   properties: [
@@ -31,6 +30,12 @@ foam.CLASS({
       name: 'contents',
       required: true,
       final: true,
+    },
+    {
+      class: 'Array',
+      of: 'String',
+      documentation: 'An array of spec URLs present within this file.',
+      name: 'specUrls',
     },
   ],
 });

--- a/lib/org/chromium/webidl/IDLFileContents.js
+++ b/lib/org/chromium/webidl/IDLFileContents.js
@@ -23,13 +23,11 @@ foam.CLASS({
       of: 'org.chromium.webidl.IDLFile',
       name: 'metadata',
       required: true,
-      final: true,
     },
     {
       class: 'String',
       name: 'contents',
       required: true,
-      final: true,
     },
     {
       class: 'Array',

--- a/lib/org/chromium/webidl/URLExtractor.js
+++ b/lib/org/chromium/webidl/URLExtractor.js
@@ -7,8 +7,6 @@ foam.CLASS({
   package: 'org.chromium.webidl',
   name: 'URLExtractor',
 
-  requires: ['org.chromium.webidl.IDLFileContents'],
-
   properties: [
     {
       name: 'exclude',
@@ -47,9 +45,9 @@ foam.CLASS({
   },
 
   methods: [
-    function extract(file) {
-      if (this.IDLFileContents.isInstance(file)) {
-        var urls = file.contents.match(this.URL_REGEX) || [];
+    function extract(contents) {
+      if (foam.String.isInstance(contents)) {
+        var urls = contents.match(this.URL_REGEX) || [];
         var includeExp = this.includeRegexp_;
         var excludeExp = this.excludeRegexp_;
 

--- a/lib/org/chromium/webidl/URLExtractor.js
+++ b/lib/org/chromium/webidl/URLExtractor.js
@@ -25,6 +25,7 @@ foam.CLASS({
           });
           return new RegExp(exps.join('|'));
         }
+        return null;
       },
     },
     {
@@ -36,6 +37,7 @@ foam.CLASS({
           });
           return new RegExp(exps.join('|'));
         }
+        return null;
       },
     },
   ],
@@ -52,8 +54,8 @@ foam.CLASS({
         var excludeExp = this.excludeRegexp_;
 
         return urls.filter(function(url) {
-          return (includeExp === undefined || !!url.match(includeExp)) &&
-              (excludeExp === undefined ||  !url.match(excludeExp));
+          return (includeExp === null || !!url.match(includeExp)) &&
+              (excludeExp === null ||  !url.match(excludeExp));
         });
       }
     },

--- a/lib/org/chromium/webidl/URLExtractor.js
+++ b/lib/org/chromium/webidl/URLExtractor.js
@@ -19,7 +19,7 @@ foam.CLASS({
     {
       name: 'excludeRegexp_',
       expression: function(exclude) {
-        if (foam.Array.isInstance(exclude)) {
+        if (Array.isArray(exclude)) {
           var exps = exclude.map(function(exp) {
             return exp.source;
           });
@@ -31,7 +31,7 @@ foam.CLASS({
     {
       name: 'includeRegexp_',
       expression: function(include) {
-        if (foam.Array.isInstance(include)) {
+        if (Array.isArray(include)) {
           var exps = include.map(function(exp) {
             return exp.source;
           });
@@ -48,7 +48,7 @@ foam.CLASS({
 
   methods: [
     function extract(contents) {
-      if (foam.String.isInstance(contents)) {
+      if (typeof contents === 'string') {
         var urls = contents.match(this.URL_REGEX) || [];
         var includeExp = this.includeRegexp_;
         var excludeExp = this.excludeRegexp_;

--- a/test/any/URLExtractor-test.js
+++ b/test/any/URLExtractor-test.js
@@ -5,26 +5,22 @@
 
 describe('URL Extractor', function() {
   var URLExtractor;
-  var IDLFileContents;
 
   beforeEach(function() {
     URLExtractor = foam.lookup('org.chromium.webidl.URLExtractor');
-    IDLFileContents = foam.lookup('org.chromium.webidl.IDLFileContents');
   });
 
   it('should return undefined for passing incorrect parameter type', function() {
     var extractor = URLExtractor.create();
-    var results = extractor.extract('Test content');
+    var results = extractor.extract({contents: 'Some sort of stuff here'});
     expect(results).toBeUndefined();
   });
 
   it('should return no URLs', function() {
     var extractor = URLExtractor.create();
-    var file = IDLFileContents.create({
-      contents: 'Test content',
-    });
+    var contents = 'Test content';
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(0);
   });
@@ -34,18 +30,16 @@ describe('URL Extractor', function() {
     var urls = ['http://www.google.com', 'https://www.google.com/',
         'ftp://www.google.com', 'http://google.com', 'https://google.com',
         'https://google.com/potato?hello=true', 'www.google.com'];
-    var file = IDLFileContents.create({
-      contents: `
-        Hello World! ${urls[0]} Some other thing potato ${urls[1]} test
-        test ${urls[2]} potato
-        test ${urls[3]} test
-        potato ${urls[4]} potato
-        ${urls[5]}
-        test ${urls[6]} test
-      `,
-    });
+    var contents = `
+      Hello World! ${urls[0]} Some other thing potato ${urls[1]} test
+      test ${urls[2]} potato
+      test ${urls[3]} test
+      potato ${urls[4]} potato
+      ${urls[5]}
+      test ${urls[6]} test
+    `;
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(5);
     expect(results[0]).toBe(urls[0]);
@@ -59,15 +53,13 @@ describe('URL Extractor', function() {
 
   it('should match URLs up until the anchor', function() {
     var extractor = URLExtractor.create();
-    var urls = [ 'http://www.google.com#test', 'https://google.com#test#test2' ];
-    var file = IDLFileContents.create({
-      contents: `
-        No anchor test 1 ${urls[0]}
-        No anchor test 2 ${urls[1]}
-      `,
-    });
+    var urls = ['http://www.google.com#test', 'https://google.com#test#test2'];
+    var contents = `
+      No anchor test 1 ${urls[0]}
+      No anchor test 2 ${urls[1]}
+    `;
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(2);
     expect(results[0]).toBe('http://www.google.com');
@@ -79,17 +71,15 @@ describe('URL Extractor', function() {
     var extractor = URLExtractor.create({include: include});
     var urls = ['http://google.com', 'http://potato.com', 'https://google.ca',
       'https://calendar.google.com', 'http://about.potato.com'];
-    var file = IDLFileContents.create({
-      contents: `
-        This url should be accepted ${urls[0]}
-        This url is not whitelisted ${urls[1]}
-        This url is not whitelisted ${urls[2]}
-        This url should be accepted ${urls[3]}
-        This url is not whitelisted ${urls[4]}
-      `,
-    });
+    var contents = `
+      This url should be accepted ${urls[0]}
+      This url is not whitelisted ${urls[1]}
+      This url is not whitelisted ${urls[2]}
+      This url should be accepted ${urls[3]}
+      This url is not whitelisted ${urls[4]}
+    `;
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(2);
     expect(results[0]).toBe(urls[0]);
@@ -101,17 +91,15 @@ describe('URL Extractor', function() {
     var extractor = URLExtractor.create({exclude: exclude});
     var urls = ['http://google.com', 'http://potato.com', 'https://google.ca',
       'https://calendar.google.com', 'http://about.potato.com'];
-    var file = IDLFileContents.create({
-      contents: `
-        This url should be accepted ${urls[0]},
-        This url is blacklisted ${urls[1]},
-        This url should be accepted ${urls[2]},
-        This url is blacklisted ${urls[3]},
-        This url is blacklisted ${urls[4]}
-      `,
-    });
+    var contents = `
+      This url should be accepted ${urls[0]},
+      This url is blacklisted ${urls[1]},
+      This url should be accepted ${urls[2]},
+      This url is blacklisted ${urls[3]},
+      This url is blacklisted ${urls[4]}
+    `;
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(2);
     expect(results[0]).toBe(urls[0]);
@@ -127,17 +115,15 @@ describe('URL Extractor', function() {
     });
     var urls = ['https://www.google.com', 'http://calendar.google.com',
     'http://mail.google.com', 'https://about.potato.com', 'http://google.ca'];
-    var file = IDLFileContents.create({
-      contents: `
-        This url should be accepted ${urls[0]}
-        This url is blacklisted ${urls[1]}
-        This url should be accepted ${urls[2]}
-        This url is not whitelisted ${urls[3]}
-        This url should be accepted ${urls[4]}
-      `,
-    });
+    var contents = `
+      This url should be accepted ${urls[0]}
+      This url is blacklisted ${urls[1]}
+      This url should be accepted ${urls[2]}
+      This url is not whitelisted ${urls[3]}
+      This url should be accepted ${urls[4]}
+    `;
 
-    var results = extractor.extract(file);
+    var results = extractor.extract(contents);
     expect(results).toBeDefined();
     expect(results.length).toBe(3);
     expect(results[0]).toBe(urls[0]);


### PR DESCRIPTION
This change allows us (once the pipeline is going) to continuously stream files instead of waiting for all files to be fetched from repositories first.

`URLExtractor` has been changed to accept text content instead to allow of preprocessing of URLs for usage in creation in `IDLFileContents`