### PR TITLE
Converting IDLFragmentExtractor whatwg test to manual test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 test/node/parsing/* linguist-generated
-test/node/parsing/IDLFragmentExtractor-test.js linguist-generated=false
+test/node/parsing/*.js linguist-generated=false

--- a/test/node/parsing/IDLFragmentExtractor-manual.js
+++ b/test/node/parsing/IDLFragmentExtractor-manual.js
@@ -1,0 +1,63 @@
+// Copyright 2017 The Chromium Authors. ALl rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('IDLFragmentExtractor-manual', function() {
+  var HTMLFileContents;
+  var IDLFragmentExtractor;
+  var HTTPRequest;
+
+  function cmpTest(testName, testDirectory, numExpectedIDLFragments, raw) {
+    var fs = require('fs');
+    var dir = `${testDirectory}/${raw ? 'spec-raw' : 'spec'}.html`;
+    var spec = fs.readFileSync(dir).toString();
+    var htmlFile = HTMLFileContents.create({
+      url: dir, // Setting URL to dir for testing purposes only.
+      timestamp: new Date(),
+      contents: spec,
+    });
+
+    var extractor = IDLFragmentExtractor.create({file: htmlFile});
+    var idlFragments = extractor.idlFragments;
+
+    // Determine the number of fragments that were found.
+    expect(idlFragments.length).toBe(numExpectedIDLFragments);
+
+    fs.readdir(testDirectory, function(err, files) {
+      // Go through each of the expected results in the folder.
+      files.forEach(function(filename) {
+        var testNum = Number(filename);
+
+        if (!isNaN(testNum) && testNum < idlFragments.length) {
+          var path = `${testDirectory}/${filename}`;
+          var expectedContent = fs.readFileSync(path).toString();
+          expect(idlFragments[testNum].trim()).toBe(expectedContent.trim());
+        } else if (filename !== 'spec.html' && filename !== 'spec-raw.html') {
+          fail(`File ${filename} was not used in ${testName} spec test`);
+        }
+      });
+    });
+  }
+
+  beforeEach(function() {
+    HTTPRequest = foam.lookup('foam.net.web.HTTPRequest');
+    HTMLFileContents = foam.lookup('org.chromium.webidl.HTMLFileContents');
+    IDLFragmentExtractor = foam.lookup('org.chromium.webidl.IDLFragmentExtractor');
+  });
+
+  describe('should parse the whatwg HTML standard', function() {
+    var testDirectory = `${__dirname}/whatwg`;
+    var expectedFragments = 178;
+
+    // To be used for debugging purposes. Too much memory will be used
+    // if this and raw is run together.
+    it('Properly formatted', function() {
+      cmpTest('whatwg HTML Standard (Properly formatted)', testDirectory, expectedFragments);
+    });
+
+    it('Raw', function() {
+      cmpTest('whatwg HTML Standard (Raw)', testDirectory, expectedFragments, true);
+    });
+  });
+});

--- a/test/node/parsing/IDLFragmentExtractor-manual.js
+++ b/test/node/parsing/IDLFragmentExtractor-manual.js
@@ -6,44 +6,13 @@
 describe('IDLFragmentExtractor-manual', function() {
   var HTMLFileContents;
   var IDLFragmentExtractor;
-  var HTTPRequest;
-
-  function cmpTest(testName, testDirectory, numExpectedIDLFragments, raw) {
-    var fs = require('fs');
-    var dir = `${testDirectory}/${raw ? 'spec-raw' : 'spec'}.html`;
-    var spec = fs.readFileSync(dir).toString();
-    var htmlFile = HTMLFileContents.create({
-      url: dir, // Setting URL to dir for testing purposes only.
-      timestamp: new Date(),
-      contents: spec,
-    });
-
-    var extractor = IDLFragmentExtractor.create({file: htmlFile});
-    var idlFragments = extractor.idlFragments;
-
-    // Determine the number of fragments that were found.
-    expect(idlFragments.length).toBe(numExpectedIDLFragments);
-
-    fs.readdir(testDirectory, function(err, files) {
-      // Go through each of the expected results in the folder.
-      files.forEach(function(filename) {
-        var testNum = Number(filename);
-
-        if (!isNaN(testNum) && testNum < idlFragments.length) {
-          var path = `${testDirectory}/${filename}`;
-          var expectedContent = fs.readFileSync(path).toString();
-          expect(idlFragments[testNum].trim()).toBe(expectedContent.trim());
-        } else if (filename !== 'spec.html' && filename !== 'spec-raw.html') {
-          fail(`File ${filename} was not used in ${testName} spec test`);
-        }
-      });
-    });
-  }
+  var cmpTest;
 
   beforeEach(function() {
-    HTTPRequest = foam.lookup('foam.net.web.HTTPRequest');
     HTMLFileContents = foam.lookup('org.chromium.webidl.HTMLFileContents');
     IDLFragmentExtractor = foam.lookup('org.chromium.webidl.IDLFragmentExtractor');
+    cmpTest = global.idlFragmentExtractorTest.bind(this,
+      HTMLFileContents, IDLFragmentExtractor);
   });
 
   describe('should parse the whatwg HTML standard', function() {

--- a/test/node/parsing/IDLFragmentExtractor-test.js
+++ b/test/node/parsing/IDLFragmentExtractor-test.js
@@ -6,42 +6,13 @@
 describe('IDLFragmentExtractor', function() {
   var HTMLFileContents;
   var IDLFragmentExtractor;
-
-  function cmpTest(testName, testDirectory, numExpectedIDLFragments, raw) {
-    var fs = require('fs');
-    var dir = `${testDirectory}/${raw ? 'spec-raw' : 'spec'}.html`;
-    var spec = fs.readFileSync(dir).toString();
-    var htmlFile = HTMLFileContents.create({
-      url: dir, // Setting URL to dir for testing purposes only.
-      timestamp: new Date(),
-      contents: spec,
-    });
-
-    var extractor = IDLFragmentExtractor.create({file: htmlFile});
-    var idlFragments = extractor.idlFragments;
-
-    // Determine the number of fragments that were found.
-    expect(idlFragments.length).toBe(numExpectedIDLFragments);
-
-    fs.readdir(testDirectory, function(err, files) {
-      // Go through each of the expected results in the folder.
-      files.forEach(function(filename) {
-        var testNum = Number(filename);
-
-        if (!isNaN(testNum) && testNum < idlFragments.length) {
-          var path = `${testDirectory}/${filename}`;
-          var expectedContent = fs.readFileSync(path).toString();
-          expect(idlFragments[testNum].trim()).toBe(expectedContent.trim());
-        } else if (filename !== 'spec.html' && filename !== 'spec-raw.html') {
-          fail(`File ${filename} was not used in ${testName} spec test`);
-        }
-      });
-    });
-  }
+  var cmpTest;
 
   beforeEach(function() {
     HTMLFileContents = foam.lookup('org.chromium.webidl.HTMLFileContents');
     IDLFragmentExtractor = foam.lookup('org.chromium.webidl.IDLFragmentExtractor');
+    cmpTest = global.idlFragmentExtractorTest.bind(this,
+      HTMLFileContents, IDLFragmentExtractor);
   });
 
   it('should parse a pre tag with no content', function() {

--- a/test/node/parsing/IDLFragmentExtractor-test.js
+++ b/test/node/parsing/IDLFragmentExtractor-test.js
@@ -182,19 +182,4 @@ describe('IDLFragmentExtractor', function() {
       cmpTest('Console (Raw)', testDirectory, expectedFragments, true);
     });
   });
-
-  describe('should parse the whatwg HTML standard', function() {
-    var testDirectory = `${__dirname}/whatwg`;
-    var expectedFragments = 178;
-
-    // To be used for debugging purposes. Too much memory will be used
-    // if this and raw is run together.
-    // it('Properly formatted', function() {
-    //   cmpTest('whatwg HTML Standard (Properly formatted)', testDirectory, expectedFragments);
-    // });
-
-    it('Raw', function() {
-      cmpTest('whatwg HTML Standard (Raw)', testDirectory, expectedFragments, true);
-    });
-  });
 });

--- a/test/node/parsing/idlFragmentExtractorTest-helper.js
+++ b/test/node/parsing/idlFragmentExtractorTest-helper.js
@@ -1,0 +1,38 @@
+// Copyright 2017 The Chromium Authors. ALl rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+global.idlFragmentExtractorTest =
+  function(HTMLFileContents, IDLFragmentExtractor,
+      testName, testDirectory, numExpectedIDLFragments, raw) {
+    var fs = require('fs');
+    var dir = `${testDirectory}/${raw ? 'spec-raw' : 'spec'}.html`;
+    var spec = fs.readFileSync(dir).toString();
+    var htmlFile = HTMLFileContents.create({
+      url: dir, // Setting URL to dir for testing purposes only.
+      timestamp: new Date(),
+      contents: spec,
+    });
+
+    var extractor = IDLFragmentExtractor.create({file: htmlFile});
+    var idlFragments = extractor.idlFragments;
+
+    // Determine the number of fragments that were found.
+    expect(idlFragments.length).toBe(numExpectedIDLFragments);
+
+    fs.readdir(testDirectory, function(err, files) {
+      // Go through each of the expected results in the folder.
+      files.forEach(function(filename) {
+        var testNum = Number(filename);
+
+        if (!isNaN(testNum) && testNum < idlFragments.length) {
+          var path = `${testDirectory}/${filename}`;
+          var expectedContent = fs.readFileSync(path).toString();
+          expect(idlFragments[testNum].trim()).toBe(expectedContent.trim());
+        } else if (filename !== 'spec.html' && filename !== 'spec-raw.html') {
+          fail(`File ${filename} was not used in ${testName} spec test`);
+        }
+      });
+    });
+  };


### PR DESCRIPTION
This change is made due to memory concerns (and increasing testing time). As we add new tests, we get approach the memory limit again. In order to avoid future flaky tests (due to Node crashing from out of memory), I think it is best if parsing the whatwg HTML spec gets converted to a manual test.