### PR TITLE
Fix for typo in "qualifiers" property in Parser

### DIFF
--- a/lib/org/chromium/webidl/Parser.js
+++ b/lib/org/chromium/webidl/Parser.js
@@ -495,7 +495,7 @@ foam.CLASS({
           });
         },
         Operation: function(v) {
-          v[2].qualifieres = v[0];
+          v[2].qualifiers = v[0];
           v[2].returnType = v[1];
           return v[2];
         },


### PR DESCRIPTION
No review requested. Simple typo correction.