### PR TITLE
IDL Parser: Add support for read-only attributes in namespaces

### DIFF
--- a/lib/org/chromium/webidl/Parser.js
+++ b/lib/org/chromium/webidl/Parser.js
@@ -186,10 +186,18 @@ foam.CLASS({
                   sym('ExtendedAttributeList'), sym('NamespaceMember'))),
               // NOTE: Spec uses "ReturnType" below, instead of Type. Rely on
               // semantic actions to care about the difference.
-              // TODO: Namespace members should only include Operation. Const
-              // added here to deal with Gecko's use of consts in "console"
-              // namespace.
-              NamespaceMember: alt(sym('Const'), sym('Operation')),
+              //
+              // TODO: Attributes in namespaces should be strictly read-only.
+              // Current ReadOnlyAttributeRest marks "readonly" string as
+              // optional.
+              //
+              // TODO: Namespace members should only include read-only
+              // attributes and operations. Const added here to deal with
+              // Gecko's use of consts in "console" namespace.
+              NamespaceMember: alt(
+                  sym('Const'),
+                  sym('ReadOnlyAttributeRest'),
+                  sym('Operation')),
 
               // Partials.
               Partial: tseq1(1, 'partial', sym('PartialDefinition')),


### PR DESCRIPTION
Towards #73. See https://heycam.github.io/webidl/#idl-namespaces for spec details.