### PR TITLE
Relaxing diff conditions on different objects.

### DIFF
--- a/lib/org/chromium/webidl/Diff.js
+++ b/lib/org/chromium/webidl/Diff.js
@@ -276,19 +276,13 @@ foam.CLASS({
           var leftProps = left.cls_.getAxiomsByClass(foam.core.Property);
           var rightProps = right.cls_.getAxiomsByClass(foam.core.Property);
 
-          // Determine if left and right have the same properties.
-          // FUTURE: Relax condition and iterate over sorted collections of
-          // left and right properties.
-          if (foam.util.compare(leftProps, rightProps) !== 0) {
-            // Cannot perform a deep comparison of the objects.
-            this.addChunk_(id, this.DiffStatus.VALUES_DIFFER, left,
-                right, changes);
-            return;
-          }
+          // Perform a diff on all common properties.
+          var props = leftProps.concat(rightProps);
+          props = props.filter(function(prop, index) {
+            return props.indexOf(prop) === index;
+          });
 
-          // leftProp and rightProp are same at this point.
-          // Perform diff on each of the objects properties.
-          leftProps.forEach(function(prop) {
+          props.forEach(function(prop) {
             var propName = prop.name;
             if (this.excludedProps.includes(propName)) return;
 

--- a/lib/org/chromium/webidl/Diff.js
+++ b/lib/org/chromium/webidl/Diff.js
@@ -276,7 +276,7 @@ foam.CLASS({
           var leftProps = left.cls_.getAxiomsByClass(foam.core.Property);
           var rightProps = right.cls_.getAxiomsByClass(foam.core.Property);
 
-          // Perform a diff on all common properties.
+          // Perform a diff all properties of left and right.
           var props = leftProps.concat(rightProps);
           props = props.filter(function(prop, index) {
             return props.indexOf(prop) === index;

--- a/lib/org/chromium/webidl/Diff.js
+++ b/lib/org/chromium/webidl/Diff.js
@@ -277,8 +277,9 @@ foam.CLASS({
           var rightProps = right.cls_.getAxiomsByClass(foam.core.Property);
 
           // Perform a diff on all common properties.
-          var props = leftProps.filter(function(prop) {
-            return rightProps.indexOf(prop) !== -1;
+          var props = leftProps.concat(rightProps);
+          props = props.filter(function(prop, index) {
+            return props.indexOf(prop) === index;
           });
 
           props.forEach(function(prop) {

--- a/lib/org/chromium/webidl/Diff.js
+++ b/lib/org/chromium/webidl/Diff.js
@@ -277,9 +277,8 @@ foam.CLASS({
           var rightProps = right.cls_.getAxiomsByClass(foam.core.Property);
 
           // Perform a diff on all common properties.
-          var props = leftProps.concat(rightProps);
-          props = props.filter(function(prop, index) {
-            return props.indexOf(prop) === index;
+          var props = leftProps.filter(function(prop) {
+            return rightProps.indexOf(prop) !== -1;
           });
 
           props.forEach(function(prop) {


### PR DESCRIPTION
Previously, static members and non-static members differed at the `definition.members` level. As a result, we were not able to perform a detailed diff on static vs non-static members (static members wrapped around the actual `member` object, thus the fields were "different"). With #80 in place, that problem went away and we should now be able to relax the diff conditions and perform a deep diff on objects.