### PR TITLE
Adding ability to allow for data to be locally persisted.

### DIFF
--- a/config/files.js
+++ b/config/files.js
@@ -118,6 +118,8 @@
     `lib${sep}org${sep}chromium${sep}webidl${sep}DiffStatus.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}DiffResult.js`,
 
+    `lib${sep}org${sep}chromium${sep}webidl${sep}JournalingContainer.js`,
+
     // Pipeline components
     `lib${sep}org${sep}chromium${sep}webidl${sep}PipelineRunner.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}URLExtractor.js`,

--- a/lib/org/chromium/webidl/JournalingContainer.js
+++ b/lib/org/chromium/webidl/JournalingContainer.js
@@ -1,0 +1,50 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  package: 'org.chromium.webidl',
+  name: 'JournalingContainer',
+
+  documentation: 'Provides a DAO which allows data to be persisted in a file.',
+
+  requires: [
+    'foam.dao.JDAO',
+    'foam.dao.NullDAO',
+    'foam.dao.NodeFileJournal',
+  ],
+
+  exports: ['getDAO'],
+
+  properties: [
+    {
+      class: 'String',
+      documentation: 'The directory where all journals should be placed.',
+      name: 'outputDir',
+      required: true,
+    },
+    {
+      name: 'fs_',
+      factory: function() { return require('fs'); },
+    },
+    {
+      name: 'path_',
+      factory: function() { return require('path'); },
+    },
+  ],
+
+  methods: [
+    function getDAO(cls, name) {
+      var self = this;
+      return this.JDAO.create({
+        delegate: self.NullDAO.create({of: cls}),
+        journal: self.NodeFileJournal.create({
+          fd: self.fs_.openSync(
+              self.path_.resolve(this.outputDir, `${name}-journal.js`),
+              'w+'),
+        }),
+      });
+    },
+  ],
+});

--- a/lib/org/chromium/webidl/LocalGitRunner.js
+++ b/lib/org/chromium/webidl/LocalGitRunner.js
@@ -14,7 +14,10 @@ foam.CLASS({
     'org.chromium.webidl.URLExtractor',
   ],
 
-  imports: [ 'getDAO?' ],
+  imports: [
+    'getDAO?',
+    'source?',
+  ],
 
   constants: {
     // Path to repository fetch script, relative to this script's location.
@@ -115,8 +118,11 @@ foam.CLASS({
           of the output.`,
       name: 'outputDAO',
       factory: function() {
+        var filename =
+            `${this.cls_.name}${this.source ? '-' + this.source.label : ''}`;
         return this.getDAO ?
-            this.getDAO('org.chromium.webidl.IDLFileContents') : null;
+            this.getDAO('org.chromium.webidl.IDLFileContents', filename) :
+            null;
       },
     },
     {

--- a/lib/org/chromium/webidl/PipelineRunner.js
+++ b/lib/org/chromium/webidl/PipelineRunner.js
@@ -14,7 +14,10 @@ foam.CLASS({
     'org.chromium.webidl.CanonicalCollection',
   ],
 
-  imports: [ 'getDAO?' ],
+  imports: [
+    'getDAO?',
+    'source?',
+  ],
 
   properties: [
     {
@@ -32,14 +35,17 @@ foam.CLASS({
           will be forwarded to the given DAO (for persistent storage).`,
       name: 'outputDAO',
       factory: function() {
-        return this.getDAO ? this.getDAO(this.outputType) : null;
+        var filename =
+            `${this.cls_.name}${this.source ? '-' + this.source.label : ''}`;
+        return this.getDAO ?
+            this.getDAO(this.outputType, `${filename}`) : null;
       },
     },
   ],
 
   methods: [
     function fmtErrorMsg(msg, fnName) {
-      return `${this.cls_id}.${fnName}(): ${msg}`;
+      return `${this.cls_.id}.${fnName}(): ${msg}`;
     },
     function validateMessage(msg) {
       if (!this.inputType.isInstance(msg)) {
@@ -54,6 +60,7 @@ foam.CLASS({
       if (!this.outputType.isInstance(msg))
         console.warn(
             this.fmtErrorMsg('Message does not match outputType!', 'output'));
+
       this.outputDAO && this.outputDAO.put(msg);
       this.SUPER(msg);
     },

--- a/test/node/JournalingContainer-test.js
+++ b/test/node/JournalingContainer-test.js
@@ -1,0 +1,66 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('JournalingContainer', function() {
+  var DummyClass;
+  var execSync = require('child_process').execSync;
+  var fs = require('fs');
+  var path = require('path');
+  var container;
+  var tmp;
+
+  beforeEach(function() {
+    foam.CLASS({
+      package: 'org.chromium.webidl.test',
+      name: 'DummyClass',
+      properties: ['id'],
+    });
+    DummyClass = foam.lookup('org.chromium.webidl.test.DummyClass');
+
+    var JournalingContainer = foam.lookup('org.chromium.webidl.JournalingContainer');
+    tmp = execSync('mktemp -d').toString().trim(-1);
+    container = JournalingContainer.create({outputDir: tmp});
+  });
+
+  afterEach(function() {
+    execSync(`/bin/rm -rf "${tmp}"`);
+  });
+
+  it('getDAO should return a DAO', function() {
+    var filename = 'test';
+    var res = container.getDAO('org.chromium.webidl.test.DummyClass', filename);
+    expect(foam.dao.DAO.isInstance(res)).toBe(true);
+    // Expecting a file to be created at the given path as well.
+    expect(fs.existsSync(path.resolve(tmp, `${filename}-journal.js`))).toBe(true);
+  });
+
+  it('should write data to file on put', function(done) {
+    var filename = 'test';
+    var journal = container.getDAO('org.chromium.webidl.test.DummyClass', filename);
+    var testObj = DummyClass.create({id: 1});
+
+    journal.put(testObj).then(function() {
+      var filepath = path.resolve(tmp, `${filename}-journal.js`);
+      // Determine if file exists.
+      expect(fs.existsSync(filepath)).toBe(true);
+
+      // Expect the data to be retrieved properly.
+      var arrayDao = foam.dao.ArrayDAO.create();
+
+      foam.dao.JDAO.create({
+        delegate: arrayDao,
+        journal: foam.dao.NodeFileJournal.create({
+          fd: fs.openSync(filepath, 'r+')
+        }),
+      }).select().then(function() {
+        arrayDao.select().then(function(items) {
+          expect(items.array.length).toBe(1);
+          expect(foam.util.compare(items.array[0], testObj)).toBe(0);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Note that `source` is imported in `PipelineRunner` and `LocalGitRunner`.
This allows us to specify a filename with a source (e.g. `LocalGitRunner-Blink-journal.js`) without explicitly setting the filename for each class that is instantiated in the pipeline.

If no `source` is present, then the name simply becomes `<classname>-journal.js` (useful for `DiffRunner` since there is no specific source the journal belongs to)