### PR TITLE
Changing how multiple Enum/Typedef definitions are handled.

### DIFF
--- a/lib/org/chromium/webidl/Canonicalizer.js
+++ b/lib/org/chromium/webidl/Canonicalizer.js
@@ -138,19 +138,18 @@ foam.CLASS({
           Canonical definitions.`,
       name: 'enumCmp_',
       code: function(left, right) {
-        // Work on clones of definitions.
-        var leftClone = left.clone();
-        var rightClone = right.clone();
-        var leftMem = leftClone.definition.members;
-        var rightMem = rightClone.definition.members;
-        var id = left.id; // Name of definition is same for left and right.
-
-        // Allow the left hand side to always be the potential superset.
-        if (leftMem.length < rightMem.length) {
-          var tmp = leftMem;
-          var rightMem = leftMem;
-          var leftMem = tmp;
+        // Allow the left handside to always be the potential superset.
+        if (left.definition.members.length < right.definition.members.length) {
+          this.enumCmp_(right, left);
+          return;
         }
+
+        // Work on clones of definitions.
+        var leftClone = left.definition.clone();
+        var rightClone = right.definition.clone();
+        var leftMem = leftClone.members;
+        var rightMem = rightClone.members;
+        var id = left.id; // Name of definition is same for left and right.
 
         leftMem.forEach(function(leftItem) {
           rightMem.some(function(rightItem, index) {
@@ -169,9 +168,7 @@ foam.CLASS({
           this.canonicalMap_[id] = null;
         } else {
           // Set it to the superset.
-          this.canonicalMap_[id] =
-              left.definition.members.length > right.definition.members.length
-              ? left : right;
+          this.canonicalMap_[id] = left;
         }
       },
     },

--- a/lib/org/chromium/webidl/Canonicalizer.js
+++ b/lib/org/chromium/webidl/Canonicalizer.js
@@ -75,21 +75,38 @@ foam.CLASS({
             'Canonicalizer: Expected id field of AST to be defined.');
         var result = this.canonicalMap_[ast.id];
 
-        if (!result) {
+        if (result === undefined) {
           // No definition of this name was found.
           // We add a copy of ourselves into the map.
           clone.definition.isCanonical = true;
           this.canonicalMap_[ast.id] = clone;
-        } else if (this.Enum.isInstance(ast.definition) ||
-            this.Typedef.isInstance(ast.definition)) {
-          // An Enum or Typedef with the same name was previously defined!
-          console.warn(`Canonicalizer: Encountered two definitions of type
-              Enum or Typedef with the same name ${ast.id}`);
+        } else if (this.Enum.isInstance(ast.definition)) {
+          // An Enum with the same name was previously defined.
 
-          // Convert entry into array if it is a node, and push both items on.
-          if (!Array.isArray(result))
-            this.canonicalMap_[ast.id] = [result];
-          this.canonicalMap_[ast.id].push(clone);
+          // Disjoint Enums were previously encountered.
+          // No action required, since definition is undefined.
+          if (result === null) return;
+
+          // Check to see if one is a superset of the other.
+          this.enumCmp_(result, ast);
+        } else if (this.Typedef.isInstance(ast.definition)) {
+          // A Typedef with the same name was previously defined!
+
+          // Typedefs of same name but different types previously encountered.
+          // No action required, since definition is undefined.
+          if (result === null) return;
+
+          var resultType = result.definition.type;
+          var astType = ast.definition.type;
+          if (foam.util.compare(resultType, astType) !== 0) {
+            console.warn(`Canonicalizer: Encountered two Typedef definitions
+                with the same name ${ast.id} but they have different types!
+                Definition for ${ast.id} will not exist in results!`);
+            this.canonicalMap_[ast.id] = null;
+          } else {
+            // Add reference to current Typedef.
+            result.sources = result.sources.concat(clone.sources);
+          }
         } else {
           // A definition with the same name was found.
           this.merge_(result, ast);
@@ -109,6 +126,51 @@ foam.CLASS({
         this.timer_ = setTimeout(function() {
           this.onDone(this.canonicalMap_);
         }.bind(this), this.waitTime * 1000);
+      },
+    },
+    {
+      documentation: `Determines if the two Enum definitions are joint sets. If
+          the sets are disjoint (i.e. there is a member that exists in one but
+          not the other), we emit an warning and null is placed as entry in
+          Canonical definitions. Otherwise, the superset is placed into
+          Canonical definitions.`,
+      name: 'enumCmp_',
+      code: function(left, right) {
+        // Work on clones of definitions.
+        var leftClone = left.clone();
+        var rightClone = right.clone();
+        var leftMem = leftClone.definition.members;
+        var rightMem = rightClone.definition.members;
+        var id = left.id; // Name of definition is same for left and right.
+
+        // Allow the left hand side to always be the potential superset.
+        if (leftMem.length < rightMem.length) {
+          var tmp = leftMem;
+          var rightMem = leftMem;
+          var leftMem = tmp;
+        }
+
+        for (var i = 0; i < leftMem.length; i++) {
+          for (var j = 0; j < rightMem.length; j++) {
+            if (leftMem[i].literal === rightMem[j].literal) {
+              rightMem.splice(j, 1);
+              break;
+            }
+          }
+        }
+
+        // No match was found for at least one item on the right.
+        if (rightMem.length !== 0) {
+          console.warn(`Canonicalizer: Encountered two Enum definitions with
+              the same name ${id} but they are disjoint sets!
+              Definition for ${id} will not exist in results!`);
+          this.canonicalMap_[id] = null;
+        } else {
+          // Set it to the superset.
+          this.canonicalMap_[id] =
+              left.definition.members.length > right.definition.members.length
+              ? left : right;
+        }
       },
     },
     {

--- a/lib/org/chromium/webidl/Canonicalizer.js
+++ b/lib/org/chromium/webidl/Canonicalizer.js
@@ -85,6 +85,7 @@ foam.CLASS({
 
           // Disjoint Enums were previously encountered.
           // No action required, since definition is undefined.
+          // FUTURE: Handle disjoint Enum definitions.
           if (result === null) return;
 
           // Check to see if one is a superset of the other.
@@ -94,6 +95,7 @@ foam.CLASS({
 
           // Typedefs of same name but different types previously encountered.
           // No action required, since definition is undefined.
+          // FUTURE: Handle Typedefs with different types.
           if (result === null) return;
 
           var resultType = result.definition.type;

--- a/lib/org/chromium/webidl/Canonicalizer.js
+++ b/lib/org/chromium/webidl/Canonicalizer.js
@@ -152,14 +152,14 @@ foam.CLASS({
           var leftMem = tmp;
         }
 
-        for (var i = 0; i < leftMem.length; i++) {
-          for (var j = 0; j < rightMem.length; j++) {
-            if (leftMem[i].literal === rightMem[j].literal) {
-              rightMem.splice(j, 1);
-              break;
+        leftMem.forEach(function(leftItem) {
+          rightMem.some(function(rightItem, index) {
+            if (leftItem.literal === rightItem.literal) {
+              rightMem.splice(index, 1);
+              return true; // Early break of inner loop.
             }
-          }
-        }
+          });
+        });
 
         // No match was found for at least one item on the right.
         if (rightMem.length !== 0) {

--- a/lib/org/chromium/webidl/CanonicalizerRunner.js
+++ b/lib/org/chromium/webidl/CanonicalizerRunner.js
@@ -51,6 +51,12 @@ foam.CLASS({
         return this.Canonicalizer.create({
           waitTime: this.waitTime,
           onDone: function(map) {
+            // Filter out all the nulls (caused by multiple definitions
+            // of disjoint enums or different Typedefs).
+            for (var key in map)
+              if (map.hasOwnProperty(key) && map[key] === null)
+                delete map[key];
+
             var msg = this.CanonicalCollection.create({
               definitions: map,
               source: this.source,

--- a/lib/org/chromium/webidl/Diff.js
+++ b/lib/org/chromium/webidl/Diff.js
@@ -100,14 +100,6 @@ foam.CLASS({
 
         // Iterate through definitions and perform diff.
         keys.forEach(function(key) {
-          // If an Enum or Typedef is defined multiple times in
-          // the same source (e.g. WebKit), we will get an array of items.
-          // These definitions are retained by Canonicalizer and placed
-          // into an array. These definitions should be the same.
-          // FUTURE: Handle multi definitions that are NOT the same.
-          if (Array.isArray(left[key])) this.dedupDefinition_(left, key);
-          if (Array.isArray(right[key])) this.dedupDefinition_(right, key);
-
           // Perform diff with id object to track path and source.
           var id = this.Identifier.create({
             name: key,
@@ -119,54 +111,6 @@ foam.CLASS({
         }.bind(this));
 
         return chunks;
-      },
-    },
-    {
-      documentation: `defnMap[key] should be an array of Definition AST nodes
-          with key as the name of the definition. If all definitions are the
-          same (i.e. they have the same members), the entry is replaced
-          with a reference definition.`,
-      name: 'dedupDefinition_',
-      args: [
-        {
-          documentation: 'A map of Definition AST nodes for a given source.',
-          name: 'defnMap',
-          typeName: 'Object',
-        },
-        {
-          documentation: `Name of the Definition that was defined multiple times
-              in the given source.`,
-          name: 'key',
-          typeName: 'String',
-        },
-      ],
-      returns: '',
-      code: function(defnMap, key) {
-        var id = this.Identifier.create({name: key});
-        var defns = defnMap[key];
-
-        var refDefn = defns[0];
-        for (var i = 1; i < defns.length; i++) {
-          var changes = [];
-          this.diff_(refDefn, defns[i], id, changes);
-
-          if (changes.length !== 0) {
-            // Cannot handle different definitions right now.
-            delete defnMap[key];
-            console.error(`Diff: ${key} was defined multiple times.
-                The definitions were not identical!`);
-            return;
-          }
-        }
-
-        // Concatenate the list of sources.
-        var sources = defnMap[key].reduce(function(srcArr, def) {
-          return srcArr.concat(def.sources);
-        }, []);
-
-        // Use first object as reference object.
-        defnMap[key] = defnMap[key][0];
-        defnMap[key].sources = sources;
       },
     },
     {

--- a/test/any/Canonicalizer-test.js
+++ b/test/any/Canonicalizer-test.js
@@ -347,7 +347,7 @@ describe('Canonicalizer', function() {
     });
 
     canonicalizer.addFragment(firstAst);
-    canonicalizer.addFragment(firstAst);
     canonicalizer.addFragment(secondAst);
+    canonicalizer.addFragment(firstAst);
   });
 });

--- a/test/any/Canonicalizer-test.js
+++ b/test/any/Canonicalizer-test.js
@@ -172,16 +172,74 @@ describe('Canonicalizer', function() {
     expect(console.error).toHaveBeenCalled();
   });
 
-  it('should return both Enums if they both had the same name', function(done) {
-    console.warn = jasmine.createSpy('warn');
-
+  it('should return the Enum with superset (Superset added first)', function(done) {
     var onDone = function(results) {
       expect(Object.keys(results).length).toBe(1);
       var foodEnum = results['FoodEnum'];
       expect(foodEnum).toBeDefined();
-      expect(Array.isArray(foodEnum)).toBe(true);
-      expect(foodEnum[0].definition.members.length).toBe(2);
-      expect(foodEnum[1].definition.members.length).toBe(1);
+      expect(foodEnum.definition.members.length).toBe(3);
+      done();
+    };
+
+    var firstIdl = `
+        enum FoodEnum {
+          "Bread",
+          "Spaghetti",
+          "Sushi",
+        };`;
+    var secondIdl = `
+        enum FoodEnum {
+          "Sushi"
+        };`;
+
+    var firstAst = parse(firstIdl);
+    var secondAst = parse(secondIdl);
+    var canonicalizer = Canonicalizer.create({
+      onDone: onDone,
+      waitTime: 3, // Three seconds.
+    });
+
+    canonicalizer.addFragment(firstAst);
+    canonicalizer.addFragment(secondAst);
+  });
+
+  it('should return the Enum with superset (Subset added first)', function(done) {
+    var onDone = function(results) {
+      expect(Object.keys(results).length).toBe(1);
+      var foodEnum = results['FoodEnum'];
+      expect(foodEnum).toBeDefined();
+      expect(foodEnum.definition.members.length).toBe(3);
+      done();
+    };
+
+    var firstIdl = `
+        enum FoodEnum {
+          "Sushi",
+        };`;
+    var secondIdl = `
+        enum FoodEnum {
+          "Bread",
+          "Spaghetti",
+          "Sushi",
+        };`;
+
+    var firstAst = parse(firstIdl);
+    var secondAst = parse(secondIdl);
+    var canonicalizer = Canonicalizer.create({
+      onDone: onDone,
+      waitTime: 3, // Three seconds.
+    });
+
+    canonicalizer.addFragment(firstAst);
+    canonicalizer.addFragment(secondAst);
+  });
+
+  it('should return null if disjoint Enums are added', function(done) {
+    console.warn = jasmine.createSpy('warn');
+    var onDone = function(results) {
+      expect(Object.keys(results).length).toBe(1);
+      var foodEnum = results['FoodEnum'];
+      expect(foodEnum).toBe(null);
       expect(console.warn).toHaveBeenCalled();
       done();
     };
@@ -208,14 +266,72 @@ describe('Canonicalizer', function() {
     canonicalizer.addFragment(secondAst);
   });
 
-  it('should return both Typedef if they both had the same name', function(done) {
+  it('should not process additional Enum of same name once disjoint Enum has been encountered', function(done) {
+    console.warn = jasmine.createSpy('warn');
+    var onDone = function(results) {
+      expect(Object.keys(results).length).toBe(1);
+      var foodEnum = results['FoodEnum'];
+      expect(foodEnum).toBe(null);
+      expect(console.warn).toHaveBeenCalled();
+      done();
+    };
+
+    var firstIdl = `
+        enum FoodEnum {
+          "Bread",
+          "Spaghetti",
+        };`;
+    var secondIdl = `
+        enum FoodEnum {
+          "Sushi",
+        };`;
+    var thirdIdl = `
+        enum FoodEnum {
+          "Bread",
+        };`;
+
+    var firstAst = parse(firstIdl);
+    var secondAst = parse(secondIdl);
+    var thirdAst = parse(thirdIdl);
+
+    var canonicalizer = Canonicalizer.create({
+      onDone: onDone,
+      waitTime: 3, // Three seconds.
+    });
+
+    canonicalizer.addFragment(firstAst);
+    canonicalizer.addFragment(secondAst);
+    canonicalizer.addFragment(thirdAst);
+  });
+
+  it('should return one definition for multiple similar Typedefs', function(done) {
+    var onDone = function(results) {
+      expect(Object.keys(results).length).toBe(1);
+      var typeDef = results['GLuint'];
+      expect(typeDef).toBeDefined();
+      expect(typeDef.sources.length).toBe(2);
+      done();
+    };
+
+    var firstIdl = `typedef unsigned long GLuint;`;
+    var firstAst = parse(firstIdl);
+
+    var canonicalizer = Canonicalizer.create({
+      onDone: onDone,
+      waitTime: 3,
+    });
+
+    canonicalizer.addFragment(firstAst);
+    canonicalizer.addFragment(firstAst);
+  });
+
+  it('should return null for multiple Typedef of different types', function(done) {
     console.warn = jasmine.createSpy('warn');
 
     var onDone = function(results) {
       expect(Object.keys(results).length).toBe(1);
       var typeDef = results['GLuint'];
-      expect(typeDef).toBeDefined();
-      expect(Array.isArray(typeDef)).toBe(true);
+      expect(typeDef).toBe(null);
       expect(console.warn).toHaveBeenCalled();
       done();
     };

--- a/test/any/CanonicalizerRunner-test.js
+++ b/test/any/CanonicalizerRunner-test.js
@@ -141,7 +141,7 @@ describe('CanonicalizerRunner', function() {
       expect(outputBox.results.length).toBe(1);
 
       var canonicalInterfaces = outputBox.results[0].definitions;
-      // We only expect one interface.
+      // We expect no definitions to be returned as disjoint enums are dropped.
       expect(Object.keys(canonicalInterfaces).length).toBe(0);
       done();
     }, (waitTime + 1.5) * 1000);

--- a/test/any/Diff-test.js
+++ b/test/any/Diff-test.js
@@ -932,8 +932,6 @@ describe('Diff', function() {
       expect(chunks[1].rightValue.literal).toBe('Sushi');
     });
 
-    // Enums can be defined multiple times in the same source.
-    // This occurs after canonicalization.
     it('should return no diff fragments for multiple identical definitions', function() {
       var firstEnum = createMap(
           `enum FoodEnum { "Bread", "Spaghetti", "Sushi", "Potato" };`, 'Src1');
@@ -944,76 +942,12 @@ describe('Diff', function() {
       var fourthEnum = createMap(
           `enum FoodEnum { "Bread", "Potato", "Spaghetti", "Sushi" };`, 'Src4');
 
-      // Pair up the sources (to simulate canonicalization).
-      var firstMap = { FoodEnum: [ firstEnum.FoodEnum, secondEnum.FoodEnum ] };
-      var secondMap = { FoodEnum: [ thirdEnum.FoodEnum, fourthEnum.FoodEnum ] };
-
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(chunks.length).toBe(0);
-    });
-
-    it('should return a diff fragment for multiple definition, with missing member', function() {
-      var firstEnum = createMap(
-          `enum FoodEnum { "Bread", "Spaghetti", "Sushi", "Potato" };`, 'Src1');
-      var secondEnum = createMap(
-          `enum FoodEnum { "Spaghetti", "Sushi", "Potato", "Bread" };`, 'Src2');
-      var thirdEnum = createMap(
-          `enum FoodEnum { "Potato", "Sushi", "Spaghetti" };`, 'Src3');
-      var fourthEnum = createMap(
-          `enum FoodEnum { "Potato", "Spaghetti", "Sushi" };`, 'Src4');
-
-      // Pair up the sources (to simulate canonicalization).
-      var firstMap = { FoodEnum: [ firstEnum.FoodEnum, secondEnum.FoodEnum ] };
-      var secondMap = { FoodEnum: [ thirdEnum.FoodEnum, fourthEnum.FoodEnum ] };
-
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(chunks.length).toBe(1);
-      // Expecting difference to be in members field of definition.
-      expect(chunks[0].leftKey).toBe('definition.members');
-      expect(chunks[0].rightKey).toBe('definition.members');
-      expect(chunks[0].status).toBe(DiffStatus.NO_MATCH_ON_RIGHT);
-      // Expecting sources to be added together correctly.
-      var leftSources = chunks[0].leftSources.map(function(item) {
-        return item.id;
+      var enumArr = [firstEnum, secondEnum, thirdEnum, fourthEnum];
+      enumArr.forEach(function(firstMap) {
+        enumArr.forEach(function(secondMap) {
+          expect(differ.diff(firstMap, secondMap).length).toBe(0);
+        });
       });
-      var rightSources = chunks[0].rightSources.map(function(item) {
-        return item.id;
-      });
-      expect(leftSources.includes('Src1')).toBe(true);
-      expect(leftSources.includes('Src2')).toBe(true);
-      expect(rightSources.includes('Src3')).toBe(true);
-      expect(rightSources.includes('Src4')).toBe(true);
-      // Expecting the difference to have Bread defined in left, not right.
-      expect(chunks[0].leftValue).toBeDefined();
-      expect(chunks[0].leftValue.literal).toBe('Bread');
-      expect(chunks[0].rightValue).toBeUndefined();
-    });
-
-    it('should log an error if multiple but different definitions occur', function() {
-      console.error = jasmine.createSpy('error');
-      var firstEnum = createMap(
-          `enum FoodEnum { "Bread", "Sushi", "Potato" };`, 'Src1');
-      var secondEnum = createMap(
-          `enum FoodEnum { "Fish", "Potato", "Bread" };`, 'Src2');
-      var thirdEnum = createMap(
-          `enum FoodEnum { "Potato", "Sushi", "Spaghetti" };`, 'Src3');
-      var fourthEnum = createMap(
-          `enum FoodEnum { "Potato", "Spaghetti", "Sushi" };`, 'Src4');
-
-      // Pair up the sources (to simulate canonicalization).
-      var firstMap = { FoodEnum: [ firstEnum.FoodEnum, secondEnum.FoodEnum ] };
-      var secondMap = { FoodEnum: [ thirdEnum.FoodEnum, fourthEnum.FoodEnum ] };
-
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(console.error).toHaveBeenCalled();
-      expect(chunks.length).toBe(1);
-      // Expecting difference to be in the members field of definition.
-      expect(chunks[0].leftKey).toBe('');
-      expect(chunks[0].rightKey).toBe('');
-      // Expecting the definition to be removed from left.
-      expect(chunks[0].status).toBe(DiffStatus.MISSING_DEFINITION);
-      expect(chunks[0].leftValue).toBeUndefined();
-      expect(chunks[0].rightValue).toBeDefined();
     });
   });
 
@@ -1077,72 +1011,18 @@ describe('Diff', function() {
       expect(chunks.length).toBe(1);
     });
 
-    // Typedefs can be defined multiple times in the same source.
-    // This occurs after canonicalization.
     it('should return no fragments if multiple definitions are the same', function() {
       var firstDef = createMap(`typedef sequence<Point> Points;`, 'Src1');
       var secondDef = createMap(`typedef sequence<Point> Points;`, 'Src2');
       var thirdDef = createMap(`typedef sequence<Point> Points;`, 'Src3');
       var fourthDef = createMap(`typedef sequence<Point> Points;`, 'Src4');
 
-      // Simulating canonicalization.
-      var firstMap = { Points: [ firstDef.Points, secondDef.Points ] };
-      var secondMap = { Points: [ thirdDef.Points, fourthDef.Points ] };
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(chunks.length).toBe(0);
-    });
-
-    it('should return no fragments if multiple definitions are the same', function() {
-      var firstDef = createMap(`typedef unsigned long Points;`, 'Src1');
-      var secondDef = createMap(`typedef unsigned long Points;`, 'Src2');
-      var thirdDef = createMap(`typedef long Points;`, 'Src3');
-      var fourthDef = createMap(`typedef long Points;`, 'Src4');
-
-      // Simulating canonicalization.
-      var firstMap = { Points: [ firstDef.Points, secondDef.Points ] };
-      var secondMap = { Points: [ thirdDef.Points, fourthDef.Points ] };
-
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(chunks.length).toBe(1);
-      // Expecting the difference to be in types of definition.
-      expect(chunks[0].leftKey).toBe('definition.type.name.literal');
-      expect(chunks[0].rightKey).toBe('definition.type.name.literal');
-      expect(chunks[0].status).toBe(DiffStatus.VALUES_DIFFER);
-      expect(chunks[0].leftValue).toBe('unsigned long');
-      expect(chunks[0].rightValue).toBe('long');
-      // Expecting the sources to be merged together correctly.
-      var leftSources = chunks[0].leftSources.map(function(item) {
-        return item.id;
+      var defArr = [firstDef, secondDef, thirdDef, fourthDef];
+      defArr.forEach(function(firstDef) {
+        defArr.forEach(function(secondDef) {
+          expect(differ.diff(firstDef, secondDef).length).toBe(0);
+        });
       });
-      var rightSources = chunks[0].rightSources.map(function(item) {
-        return item.id;
-      });
-      expect(leftSources.includes('Src1')).toBe(true);
-      expect(leftSources.includes('Src2')).toBe(true);
-      expect(rightSources.includes('Src3')).toBe(true);
-      expect(rightSources.includes('Src4')).toBe(true);
-    });
-
-    it('should log an error if multiple but different definitions exist', function() {
-      console.error = jasmine.createSpy('error');
-      var firstDef = createMap(`typedef unsigned long Points;`, 'Src1');
-      var secondDef = createMap(`typedef long Points;`, 'Src2');
-      var thirdDef = createMap(`typedef long Points;`, 'Src3');
-      var fourthDef = createMap(`typedef long Points;`, 'Src4');
-
-      // Simulating canonicalization.
-      var firstMap = { Points: [ firstDef.Points, secondDef.Points ] };
-      var secondMap = { Points: [ thirdDef.Points, fourthDef.Points ] };
-
-      var chunks = differ.diff(firstMap, secondMap);
-      expect(console.error).toHaveBeenCalled();
-      expect(chunks.length).toBe(1);
-      // Expecting the difference to be at definition level.
-      expect(chunks[0].leftKey).toBe('');
-      expect(chunks[0].rightKey).toBe('');
-      expect(chunks[0].status).toBe(DiffStatus.MISSING_DEFINITION);
-      expect(chunks[0].leftValue).toBeUndefined();
-      expect(chunks[0].rightValue).toBeDefined();
     });
   });
 


### PR DESCRIPTION
If multiple Enum definitions are not disjoint (i.e. one is a superset of the other), then we will now return the superset. If the Enums are disjoint, the definition will be removed completely from the dataset and a warning will be emitted.

For Typedefs, if multiple definitions of different types are encountered, a warning will be emitted and the definition will be removed as well.

Relevant issue can be found at #78