### PR TITLE
Adding IDs to remaining AST nodes

### DIFF
--- a/lib/org/chromium/webidl/IDLFileContents.js
+++ b/lib/org/chromium/webidl/IDLFileContents.js
@@ -19,7 +19,9 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.IDLFile',
       name: 'metadata',
-      required: true,
+      factory: function() {
+        return null;
+      },
     },
     {
       class: 'Array',

--- a/lib/org/chromium/webidl/ast/Attribute.js
+++ b/lib/org/chromium/webidl/ast/Attribute.js
@@ -23,6 +23,12 @@ foam.CLASS({
         return this.ctxSource;
       },
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Callback.js
+++ b/lib/org/chromium/webidl/ast/Callback.js
@@ -13,6 +13,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Parameterized',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function outputWebIDL(o) {
       this.SUPER(o);

--- a/lib/org/chromium/webidl/ast/CallbackInterface.js
+++ b/lib/org/chromium/webidl/ast/CallbackInterface.js
@@ -14,6 +14,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Interface',
       name: 'interface',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Const.js
+++ b/lib/org/chromium/webidl/ast/Const.js
@@ -13,6 +13,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Typed',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function outputWebIDL(o) {
       o.outputStrs('const ').outputObj(this.type).outputStrs(' ')

--- a/lib/org/chromium/webidl/ast/Defaulted.js
+++ b/lib/org/chromium/webidl/ast/Defaulted.js
@@ -12,6 +12,9 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.ast.Literal',
       name: 'value',
+      factory: function() {
+        return null;
+      },
     },
   ],
 });

--- a/lib/org/chromium/webidl/ast/Dictionary.js
+++ b/lib/org/chromium/webidl/ast/Dictionary.js
@@ -13,6 +13,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Membered',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function outputWebIDL(o) {
       this.SUPER(o);

--- a/lib/org/chromium/webidl/ast/DictionaryMemberData.js
+++ b/lib/org/chromium/webidl/ast/DictionaryMemberData.js
@@ -18,6 +18,12 @@ foam.CLASS({
       class: 'Boolean',
       name: 'isRequired',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Enum.js
+++ b/lib/org/chromium/webidl/ast/Enum.js
@@ -12,6 +12,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Membered',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function outputWebIDL(o) {
       this.SUPER(o);

--- a/lib/org/chromium/webidl/ast/Implements.js
+++ b/lib/org/chromium/webidl/ast/Implements.js
@@ -19,6 +19,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Literal',
       name: 'implemented',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Interface.js
+++ b/lib/org/chromium/webidl/ast/Interface.js
@@ -13,6 +13,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Membered',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function outputWebIDL(o) {
       this.SUPER(o);

--- a/lib/org/chromium/webidl/ast/Iterable.js
+++ b/lib/org/chromium/webidl/ast/Iterable.js
@@ -17,6 +17,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Type',
       name: 'valueType',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Literal.js
+++ b/lib/org/chromium/webidl/ast/Literal.js
@@ -7,6 +7,8 @@ foam.CLASS({
   package: 'org.chromium.webidl.ast',
   name: 'Literal',
 
+  ids: [ 'literal' ],
+
   properties: [
     {
       class: 'String',

--- a/lib/org/chromium/webidl/ast/MapLike.js
+++ b/lib/org/chromium/webidl/ast/MapLike.js
@@ -18,6 +18,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Type',
       name: 'valueType',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/NonUnionType.js
+++ b/lib/org/chromium/webidl/ast/NonUnionType.js
@@ -18,6 +18,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Type',
       name: 'params',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Operation.js
+++ b/lib/org/chromium/webidl/ast/Operation.js
@@ -19,6 +19,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.OperationQualifier',
       name: 'qualifiers',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/Serializer.js
+++ b/lib/org/chromium/webidl/ast/Serializer.js
@@ -13,11 +13,23 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.ast.Operation',
       name: 'operation',
+      factory: function() {
+        return null;
+      },
     },
     {
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.ast.SerializerPattern',
       name: 'pattern',
+      factory: function() {
+        return null;
+      },
+    },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
     },
   ],
 

--- a/lib/org/chromium/webidl/ast/SerializerPattern.js
+++ b/lib/org/chromium/webidl/ast/SerializerPattern.js
@@ -21,6 +21,10 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Literal',
       name: 'parts',
     },
+    {
+      name: 'id',
+      value: 'serializerPattern',
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/SetLike.js
+++ b/lib/org/chromium/webidl/ast/SetLike.js
@@ -12,6 +12,15 @@ foam.CLASS({
     'org.chromium.webidl.ast.Typed',
   ],
 
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
+  ],
+
   methods: [
     function getName() {
       // The name will look like its definition for the most part.

--- a/lib/org/chromium/webidl/ast/Stringifier.js
+++ b/lib/org/chromium/webidl/ast/Stringifier.js
@@ -13,11 +13,23 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.ast.Attribute',
       name: 'attribute',
+      factory: function() {
+        return null;
+      },
     },
     {
       class: 'FObjectProperty',
       of: 'org.chromium.webidl.ast.Operation',
       name: 'operation',
+      factory: function() {
+        return null;
+      },
+    },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
     },
   ],
 

--- a/lib/org/chromium/webidl/ast/Typedef.js
+++ b/lib/org/chromium/webidl/ast/Typedef.js
@@ -17,6 +17,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Type',
       name: 'type',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/lib/org/chromium/webidl/ast/UnionType.js
+++ b/lib/org/chromium/webidl/ast/UnionType.js
@@ -14,6 +14,12 @@ foam.CLASS({
       of: 'org.chromium.webidl.ast.Type',
       name: 'types',
     },
+    {
+      name: 'id',
+      factory: function() {
+        return this.getName();
+      },
+    },
   ],
 
   methods: [

--- a/test/any/Diff-test.js
+++ b/test/any/Diff-test.js
@@ -872,8 +872,8 @@ describe('Diff', function() {
       var chunks = differ.diff(firstMap, secondMap);
       expect(chunks.length).toBe(1);
       // Expecting the difference to be in the isRequired field of the member.
-      expect(chunks[0].leftKey).toBe('definition.members.0.member.isRequired');
-      expect(chunks[0].rightKey).toBe('definition.members.0.member.isRequired');
+      expect(chunks[0].leftKey).toBe('definition.members.2.member.isRequired');
+      expect(chunks[0].rightKey).toBe('definition.members.2.member.isRequired');
       expect(chunks[0].status).toBe(DiffStatus.VALUES_DIFFER);
       expect(chunks[0].leftValue).toBe(true);
       expect(chunks[0].rightValue).toBe(false);


### PR DESCRIPTION
Datastore requires that all entities have an ID and that all elements are not of the type `undefined`.
As a result, an ID field has been added to the remaining AST nodes, and AST properties that could have been potentially `undefined` before have been given a factory which returns `null` instead.