### PR TITLE
Adding configuration files for LocalGitRunner

### DIFF
--- a/main/blinkConfig.js
+++ b/main/blinkConfig.js
@@ -1,0 +1,34 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+var IDLFileContents = foam.lookup('org.chromium.webidl.IDLFileContents');
+var GitilesIDLFile = foam.lookup('org.chromium.webidl.GitilesIDLFile');
+var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
+var Parser = foam.lookup('org.chromium.webidl.Parser');
+
+var gitilesBaseURL = 'https://chromium.googlesource.com/chromium/src/+';
+var config = {
+  source: WebPlatformEngine.BLINK,
+  parserClass: Parser,
+  repositoryURL: 'https://chromium.googlesource.com/chromium/src.git',
+  localRepositoryPath: require('path').resolve(__dirname, 'data/blink/git'),
+  sparsePath: 'third_party/WebKit/Source',
+  findExcludePatterns: ['*/testing/*', '*/bindings/tests/*', '*/mojo/*'],
+  extension: 'idl',
+  freshRepo: true, // Forces the latest copy of repo to be fetched.
+};
+config.idlFileContentsFactory = function(path, contents, urls) {
+  return IDLFileContents.create({
+    metadata: GitilesIDLFile.create({
+      repository: this.repositoryURL,
+      gitilesBaseURL: gitilesBaseURL,
+      revision: this.commit,
+      path: path,
+    }),
+    contents: contents,
+    specUrls: urls,
+  });
+};
+module.exports = { config };

--- a/main/blinkConfig.js
+++ b/main/blinkConfig.js
@@ -8,7 +8,6 @@ var GitilesIDLFile = foam.lookup('org.chromium.webidl.GitilesIDLFile');
 var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
 var Parser = foam.lookup('org.chromium.webidl.Parser');
 
-var gitilesBaseURL = 'https://chromium.googlesource.com/chromium/src/+';
 var config = {
   source: WebPlatformEngine.BLINK,
   parserClass: Parser,
@@ -23,7 +22,7 @@ config.idlFileContentsFactory = function(path, contents, urls) {
   return IDLFileContents.create({
     metadata: GitilesIDLFile.create({
       repository: this.repositoryURL,
-      gitilesBaseURL: gitilesBaseURL,
+      gitilesBaseURL: 'https://chromium.googlesource.com/chromium/src/+',
       revision: this.commit,
       path: path,
     }),

--- a/main/geckoConfig.js
+++ b/main/geckoConfig.js
@@ -8,7 +8,6 @@ var GithubIDLFile = foam.lookup('org.chromium.webidl.GithubIDLFile');
 var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
 var GeckoParser = foam.lookup('org.chromium.webidl.GeckoParser');
 
-var githubBaseURL = 'https://github.com/mozilla/gecko-dev';
 var config = {
   source: WebPlatformEngine.GECKO,
   parserClass: GeckoParser,
@@ -23,7 +22,7 @@ config.idlFileContentsFactory = function(path, contents) {
   return IDLFileContents.create({
     metadata: GithubIDLFile.create({
       repository: this.repositoryURL,
-      githubBaseURL: githubBaseURL,
+      githubBaseURL: 'https://github.com/mozilla/gecko-dev',
       revision: this.commit,
       path: path,
     }),

--- a/main/geckoConfig.js
+++ b/main/geckoConfig.js
@@ -1,0 +1,33 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+var IDLFileContents = foam.lookup('org.chromium.webidl.IDLFileContents');
+var GithubIDLFile = foam.lookup('org.chromium.webidl.GithubIDLFile');
+var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
+var GeckoParser = foam.lookup('org.chromium.webidl.GeckoParser');
+
+var githubBaseURL = 'https://github.com/mozilla/gecko-dev';
+var config = {
+  source: WebPlatformEngine.GECKO,
+  parserClass: GeckoParser,
+  repositoryURL: 'https://github.com/mozilla/gecko-dev.git',
+  localRepositoryPath: require('path').resolve(__dirname, 'data/gecko/git'),
+  sparsePath: 'dom',
+  findExcludePatterns: ['*/test/*'],
+  extension: 'webidl',
+  freshRepo: true, // Forces the latest copy of repo to be fetched.
+};
+config.idlFileContentsFactory = function(path, contents) {
+  return IDLFileContents.create({
+    metadata: GithubIDLFile.create({
+      repository: this.repositoryURL,
+      githubBaseURL: githubBaseURL,
+      revision: this.commit,
+      path: path,
+    }),
+    contents: contents,
+  });
+};
+module.exports = { config };

--- a/main/webKitConfig.js
+++ b/main/webKitConfig.js
@@ -1,0 +1,34 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+var IDLFileContents = foam.lookup('org.chromium.webidl.IDLFileContents');
+var GithubIDLFile = foam.lookup('org.chromium.webidl.GithubIDLFile');
+var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
+var WebKitParser = foam.lookup('org.chromium.webidl.WebKitParser');
+
+var githubBaseURL = 'https://github.com/WebKit/webkit';
+var config = {
+  source: WebPlatformEngine.WEBKIT,
+  parserClass: WebKitParser,
+  repositoryURL: 'https://github.com/WebKit/webkit.git',
+  localRepositoryPath: require('path').resolve(__dirname, 'data/WebKit/git'),
+  sparsePath: 'Source/WebCore',
+  findExcludePatterns: ['*/testing/*', '*/test/*', '*/deprecated/*'],
+  extension: 'idl',
+  freshRepo: true, // Forces the latest copy of repo to be fetched.
+};
+config.idlFileContentsFactory = function(path, contents) {
+  // Classes are injected by ...
+  return IDLFileContents.create({
+    metadata: GithubIDLFile.create({
+      repository: this.repositoryURL,
+      githubBaseURL: githubBaseURL,
+      revision: this.commit,
+      path: path,
+    }),
+    contents: contents,
+  });
+};
+module.exports = { config };

--- a/main/webKitConfig.js
+++ b/main/webKitConfig.js
@@ -20,7 +20,6 @@ var config = {
   freshRepo: true, // Forces the latest copy of repo to be fetched.
 };
 config.idlFileContentsFactory = function(path, contents) {
-  // Classes are injected by ...
   return IDLFileContents.create({
     metadata: GithubIDLFile.create({
       repository: this.repositoryURL,

--- a/main/webKitConfig.js
+++ b/main/webKitConfig.js
@@ -8,7 +8,6 @@ var GithubIDLFile = foam.lookup('org.chromium.webidl.GithubIDLFile');
 var WebPlatformEngine = foam.lookup('org.chromium.webidl.WebPlatformEngine');
 var WebKitParser = foam.lookup('org.chromium.webidl.WebKitParser');
 
-var githubBaseURL = 'https://github.com/WebKit/webkit';
 var config = {
   source: WebPlatformEngine.WEBKIT,
   parserClass: WebKitParser,
@@ -23,7 +22,7 @@ config.idlFileContentsFactory = function(path, contents) {
   return IDLFileContents.create({
     metadata: GithubIDLFile.create({
       repository: this.repositoryURL,
-      githubBaseURL: githubBaseURL,
+      githubBaseURL: 'https://github.com/WebKit/webkit',
       revision: this.commit,
       path: path,
     }),


### PR DESCRIPTION
These configuration files are to be used with `LocalGitRunner`.
Expected usage: `LocalGitRunner.create(config)`


An example of the usage can be found in the `dataCollection` branch or `runner` branch. 

