### PR TITLE
Updating parsing test behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
 script:
- - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then npm run testManual; fi
- - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then npm run coverage && codecov -f .coverage/coverage-final.json -f .coverage/lcov.info; fi
+ - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+ - if [ "$TRAVIS_EVENT_TYPE" != "cron" ] || [[ "$BRANCH" == *"parser"* ]]; then npm run coverage && codecov -f .coverage/coverage-final.json -f .coverage/lcov.info; fi
+ - if [[ "$BRANCH" == *"parser"* ]]; then npm run testManual; fi

--- a/test/node/manualFetchAndParseTest-helper.js
+++ b/test/node/manualFetchAndParseTest-helper.js
@@ -13,6 +13,7 @@ global.manualFetchAndParseTest = function(configPath, description) {
     var originalTimeout;
     var outputBox;
     var errorBox;
+    var failedFiles = [];
 
     beforeAll(function() {
       // Creating new context for AccumulatorBox to be defined in.
@@ -46,6 +47,14 @@ global.manualFetchAndParseTest = function(configPath, description) {
       // Reset context and clean up repo data.
       foam.__context__ = oldContext;
       execSync(`/bin/rm -rf "${config.localRepositoryPath}"`);
+
+      if (failedFiles.length !== 0) {
+        console.log(`
+            The following files failed to parse for this repository:`);
+        failedFiles.forEach(function(file) {
+          console.log(file);
+        });
+      }
     });
 
     it('should fetch git repo and send files to outputBox', function(done) {
@@ -66,6 +75,7 @@ global.manualFetchAndParseTest = function(configPath, description) {
       results.forEach(function(result) {
         var idl = result.contents;
         var parse = parser.parseString(idl, 'Test');
+        if (parse.pos !== idl.length) failedFiles.push(result.metadata.path);
         expect(parse.pos).toBe(idl.length);
         expect(parse.value).toBeDefined();
       }.bind(this));


### PR DESCRIPTION
Travis should now execute integration tests and manual tests for branches with 'parser' in their name. Manual tests fetch all repositories and should allow us to detect any breaking parser changes.

Additionally, all files that fail to parse will now be displayed on the screen.