### PR TITLE
Add handling for 'exception' in WebIDL parser

### DIFF
--- a/config/files.js
+++ b/config/files.js
@@ -103,6 +103,7 @@
     `lib${sep}org${sep}chromium${sep}webidl${sep}CanonicalCollection.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}URLCollection.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}BaseIDLFile.js`,
+    `lib${sep}org${sep}chromium${sep}webidl${sep}FileIterator.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}IDLFile.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}IDLFileContents.js`,
     `lib${sep}org${sep}chromium${sep}webidl${sep}IDLSpecFile.js`,

--- a/config/load_deps.js
+++ b/config/load_deps.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var path = require('path');
+
+// Use config/files.js to determine what order to load code in.
+var rootDir = path.resolve(__dirname, '..');
+require(path.resolve(rootDir, 'config', 'files.js'));
+var files = global.WEB_IDL_DIFF_FILES.slice();
+for (var i = 0; i < files.length; i++) {
+  require(path.resolve(rootDir, files[i]));
+}

--- a/lib/org/chromium/webidl/FileIterator.js
+++ b/lib/org/chromium/webidl/FileIterator.js
@@ -1,0 +1,152 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  package: 'org.chromium.webidl',
+  name: 'FileIterator',
+
+  documentation: 'Box runnable of files in a directory.',
+
+  constants: {
+    // Hard-coded path to trusted `find` binary.
+    FIND_PATH: '/usr/bin/find',
+  },
+
+  properties: [
+    {
+      class: 'String',
+      documentation: 'Path to local directory.',
+      name: 'path',
+      required: true,
+      preSet: function (_, nu) {
+        return this.path_.resolve(nu);
+      },
+    },
+    {
+      class: 'String',
+      documentation: 'Extension filter for files in the directory.',
+      name: 'extension',
+      value: 'idl',
+    },
+    {
+      class: 'Array',
+      of: 'String',
+      documentation: `Shell patterns to exclude IDL files, passed to the shell
+          "find" command:
+          E.g. find [...] -not -path <pattern 1> -not -path <pattern 2> [...]`,
+      name: 'findExcludePatterns',
+    },
+    {
+      class: 'Function',
+      documentation: `Factory function for FileContents instances to be
+          stored during initialization. The caller provides the
+          directory-relative path and contents of the file; all other data are
+          implementation details of the factory.`,
+      name: 'fileContentsFactory',
+      required: true,
+    },
+    {
+      documentation: `Files that are fetched from the repositories will be
+        forwarded to this box.`,
+      name: 'outputBox',
+    },
+    {
+      documentation: 'Any errors that are encountered will be forwarded to this box.',
+      name: 'errorBox',
+    },
+    {
+      name: 'fs_',
+      factory: function () { return require('fs'); },
+    },
+    {
+      name: 'childProcess_',
+      factory: function () { return require('child_process'); },
+    },
+    {
+      name: 'path_',
+      factory: function () { return require('path'); },
+    },
+    {
+      name: 'process_',
+      factory: function () { return require('process'); },
+    },
+    {
+      name: 'onDone',
+      documentation: 'Callback function when all file have been fetched.',
+    },
+  ],
+
+  methods: [
+    function run() {
+      // Verify that required properties are present.
+      if (!this.path || !this.fileContentsFactory)
+        throw new Error("FileIterator: Missing required properties!");
+
+      // Clean repository before acquiring files.
+      this.enumerate_();
+    },
+    function enumerate_() {
+      var execStr = `"${this.FIND_PATH}" "." -type f -path ` +
+        `"*.${this.extension}"`;
+      for (var i = 0; i < this.findExcludePatterns.length; i++) {
+        execStr += ` -not -path "${this.findExcludePatterns[i]}"`;
+      }
+      this.childProcess_.exec(
+          execStr,
+          { cwd: this.path },
+          this.onPaths);
+    },
+  ],
+
+  listeners: [
+    {
+      name: 'onPaths',
+      documentation: `Handler for file paths fetch. Read file contents
+        and enqueue files for insertion into delegate.`,
+      code: function (error, stdout, sterr) {
+        if (error) throw error;
+
+        var paths = stdout.split('\n');
+        foam.assert(paths.pop() === '',
+          'FileIterator: Expected `find` output to end in empty line');
+
+        var promises = [];
+        var onFileReady = this.onFileReady;
+        var readFile = this.fs_.readFile;
+        var basePath = this.path;
+        for (var i = 0; i < paths.length; i++) {
+          // Path relative to repository root; drop "./" from "find . [...]"
+          // output.
+          var path = paths[i].substr(2);
+          // Bind "onFileReady" with file path and promise callbacks.
+          promises.push(new Promise(function (resolve, reject) {
+            readFile(`${basePath}/${paths[i]}`,
+              onFileReady.bind(this, path, resolve, reject));
+          }));
+        }
+        // Wait for all "onFileReady. Then call onDone() if it is defined.
+        Promise.all(promises).then(function () {
+          if (this.onDone) this.onDone();
+        }.bind(this));
+      },
+    },
+    {
+      name: 'onFileReady',
+      documentation: `Handler for file read. Instantiate file and contents;
+        put() them to "delegate".`,
+      code: function (path, resolve, reject, error, contents) {
+        if (error) {
+          reject(error);
+        } else {
+          // Convert contents from Buffer to String.
+          contents = contents.toString();
+          var file = this.fileContentsFactory(path, contents);
+
+          resolve(this.outputBox.send({ object: file }));
+        }
+      },
+    },
+  ],
+});

--- a/lib/org/chromium/webidl/LocalGitRunner.js
+++ b/lib/org/chromium/webidl/LocalGitRunner.js
@@ -12,6 +12,7 @@ foam.CLASS({
   requires: [
     'org.chromium.webidl.URLCollection',
     'org.chromium.webidl.URLExtractor',
+    'org.chromium.webidl.FileIterator',
   ],
 
   imports: [
@@ -21,11 +22,9 @@ foam.CLASS({
 
   constants: {
     // Path to repository fetch script, relative to this script's location.
-    scriptRelativeFetchPath: '../../../../scripts/sparse-and-shallow-git-fetch.sh',
+    SCRIPT_RELATIVE_FETCH_PATH: '../../../../scripts/sparse-and-shallow-git-fetch.sh',
     // Hard-coded path to trusted `git` binary.
-    gitPath: '/usr/bin/git',
-    // Hard-coded path to trusted `find` binary.
-    findPath: '/usr/bin/find',
+    GIT_PATH: '/usr/bin/git',
   },
 
   properties: [
@@ -73,6 +72,20 @@ foam.CLASS({
           implementation details of the factory.`,
       name: 'idlFileContentsFactory',
       required: true,
+      args: [
+        {
+          documentation: 'Path of the file',
+          name: 'path',
+        },
+        {
+          documentation: 'Contents of the file',
+          name: 'contents',
+        },
+        {
+          documentation: 'URLs extracted from of the file',
+          name: 'urls',
+        }
+      ]
     },
     {
       class: 'String',
@@ -215,72 +228,22 @@ foam.CLASS({
             `"${this.GIT_PATH}" rev-parse HEAD`,
             {cwd: this.localRepositoryPath})
                 .toString().trim();
+        
         var basePath = '.' + (this.sparsePath ? `/${this.sparsePath}` : '');
-        var execStr = `"${this.FIND_PATH}" "${basePath}" -type f -path ` +
-            `"*.${this.extension}"`;
-        for (var i = 0; i < this.findExcludePatterns.length; i++) {
-          execStr += ` -not -path "${this.findExcludePatterns[i]}"`;
-        }
-        this.childProcess_.exec(
-            execStr,
-            {cwd: this.localRepositoryPath},
-            this.onPaths);
-      },
-    },
-    {
-      name: 'onPaths',
-      documentation: `Handler for post-IDL file paths fetch. Read file contents
-        and enqueue files for insertion into delegate.`,
-      code: function(error, stdout, sterr) {
-        if (error) throw error;
-
-        var paths = stdout.split('\n');
-        foam.assert(paths.pop() === '',
-            'LocalGitRunner: Expected `find` output to end in empty line');
-
-        var promises = [];
-        var onFileReady = this.onFileReady;
-        var readFile = this.fs_.readFile;
-        var basePath = this.localRepositoryPath;
-        for (var i = 0; i < paths.length; i++) {
-          // Path relative to repository root; drop "./" from "find . [...]"
-          // output.
-          var path = paths[i].substr(2);
-          // Bind "onFileReady" with file path and promise callbacks.
-          promises.push(new Promise(function(resolve, reject) {
-            readFile(`${basePath}/${paths[i]}`,
-                     onFileReady.bind(this, path, resolve, reject));
-          }));
-        }
-        // Wait for all "onFileReady. Then call onDone() if it is defined.
-        Promise.all(promises).then(function() {
-          if (this.onDone) this.onDone();
-        }.bind(this));
-      },
-    },
-    {
-      name: 'onFileReady',
-      documentation: `Handler for post-IDL file read. Instantiate
-        "IDLFileContents" objects consistent with file metadata and contents;
-        put() them to "delegate".`,
-      code: function(path, resolve, reject, error, contents) {
-        if (error) {
-          reject(error);
-        } else {
-          // Convert contents from Buffer to String.
+        var fileToIDLFileFactory = (function(path, contents) {
           contents = contents.toString();
           var urls = this.urlExtractor_.extract(contents);
-          var file = this.idlFileContentsFactory(path, contents, urls);
-
-          if (this.urlOutputBox && urls.length > 0) {
-            // Remove trailing slash (/) in URLs then forward to urlOutputBox.
-            urls = urls.map(function(url) { return url.replace(/\/+$/, ''); });
-            var urlMsg = this.URLCollection.create({urls: urls});
-            this.urlOutputBox.send({object: urlMsg});
-          }
-          this.outputDAO && this.outputDAO.put(file);
-          resolve(this.fileOutputBox.send({object: file}));
-        }
+          return this.idlFileContentsFactory(path, contents, urls);
+        }).bind(this);
+        this.FileIterator.create({
+          path: this.localRepositoryPath,
+          extension: this.extension,
+          findExcludePatterns: this.findExcludePatterns,
+          fileContentsFactory: fileToIDLFileFactory,
+          outputBox: this.fileOutputBox,
+          errorBox: this.errorBox,
+          onDone: this.onDone,
+        }).run();
       },
     },
   ],

--- a/lib/org/chromium/webidl/Parser.js
+++ b/lib/org/chromium/webidl/Parser.js
@@ -343,9 +343,9 @@ foam.CLASS({
                   1, '=', alt(sym('ConstValue'), sym('string'),
                               sym('ArrayValue')))),
               ArrayValue: tseq('[', ']'),
-              // NOTE: Should be (ArgumentNameKeyword|identifier); we leave
-              // dealing with keywords to semantic actions.
-              ArgumentName: sym('identifier'),
+              ArgumentName: alt(
+                  sym('ArgumentNameKeyword'),
+                  sym('identifier')),
               Ellipsis: optional('...'),
 
               // Values.

--- a/main/forkScript.js
+++ b/main/forkScript.js
@@ -8,11 +8,7 @@ var path = require('path');
 require('foam2');
 
 var rootDir = path.resolve(__dirname, '..');
-require(path.resolve(rootDir, 'config', 'files.js'));
-var files = global.WEB_IDL_DIFF_FILES.slice();
-for (var i = 0; i < files.length; i++) {
-  require(path.resolve(rootDir, files[i]));
-}
+require(path.resolve(rootDir, 'config', 'load_deps.js'));
 
 require(path.resolve(
     rootDir,

--- a/test/any/parsing/GeckoParser-file-test.js
+++ b/test/any/parsing/GeckoParser-file-test.js
@@ -1,0 +1,73 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+describe('GeckoParser', function () {
+    var Parser;
+    var GeckoParser;
+    var FileIterator;
+    var BaseIDLFile;
+    var outputBox;
+    var errorBox;
+    var config;
+    var oldContext;
+  
+    beforeAll(function () {
+        Parser = foam.lookup('org.chromium.webidl.Parser');
+        GeckoParser = foam.lookup('org.chromium.webidl.GeckoParser');
+        FileIterator = foam.lookup('org.chromium.webidl.FileIterator');
+        BaseIDLFile = foam.lookup('org.chromium.webidl.BaseIDLFile');
+
+        // Creating new context for AccumulatorBox to be defined in.
+        oldContext = foam.__context__;
+        foam.__context__ = foam.createSubContext({});
+        global.defineAccumulatorBox();
+
+        var AccumulatorBox = foam.lookup('org.chromium.webidl.test.AccumulatorBox');
+        outputBox = AccumulatorBox.create();
+        errorBox = AccumulatorBox.create();
+
+        config = {
+            path: require('path').resolve(__dirname, 'data'),
+            extension: 'widl',
+            fileContentsFactory: function (path, contents) {
+                return BaseIDLFile.create({
+                    contents: contents,
+                });
+            },
+            outputBox: outputBox,
+            errorBox: errorBox,
+        }
+    });
+
+    afterAll(function () {
+        // Reset context and clean up repo data.
+        foam.__context__ = oldContext;
+    });
+
+    function parse(str, opt_production) {
+        var p = GeckoParser.create().parseString(str, 'Test', opt_production);
+        expect(p.pos).toBe(str.length);
+        expect(p.value).toBeDefined();
+        return p;
+    }
+
+    it('should collect the IDL files', function (done) {
+        var onDone = function () {
+            expect(outputBox.results.length > 0).toBe(true);
+            expect(errorBox.results.length).toBe(0);
+            done();
+        }.bind(this);
+
+        config.onDone = onDone;
+        FileIterator.create(config).run();
+    });
+
+    it('should parse all the collected IDL files', function () {
+        outputBox.results.forEach(function(result) {
+            expect(result.contents && result.contents.length).toBeTruthy();
+            parse(result.contents);
+        })
+    });
+});

--- a/test/any/parsing/data/exception.widl
+++ b/test/any/parsing/data/exception.widl
@@ -1,0 +1,44 @@
+// Extracted from http://dev.w3.org/2006/webapi/WebIDL/ on 2011-05-06
+// Typedef identifier: "number"
+// Qualified name:    "::framework::number"
+typedef float number;
+
+// Exception identifier: "FrameworkException"
+// Qualified name:       "::framework::FrameworkException"
+exception FrameworkException {
+
+    // Constant identifier: "ERR_NOT_FOUND"
+    // Qualified name:      "::framework::FrameworkException::ERR_NOT_FOUND"
+    const long ERR_NOT_FOUND = 1;
+
+    // Exception field identifier: "code"
+    long code;
+};
+
+// Interface identifier: "System"
+// Qualified name:       "::framework::System"
+interface System {
+
+    // Operation identifier:          "createObject"
+    // Operation argument identifier: "interface"
+    object createObject(DOMString _interface);
+
+// Operation has no identifier; it declares a getter.
+getter DOMString(DOMString keyName);
+  };
+
+
+// Interface identifier: "TextField"
+// Qualified name:       "::framework::gui::TextField"
+interface TextField {
+
+      // Attribute identifier: "const"
+      attribute boolean _const;
+
+// Attribute identifier: "value"
+attribute DOMString ? _value;
+    };
+
+interface Foo {
+ void op(object interface);
+};

--- a/test/node/manualFetchAndParseTest-helper.js
+++ b/test/node/manualFetchAndParseTest-helper.js
@@ -24,7 +24,7 @@ global.manualFetchAndParseTest = function(configPath, description) {
       config = require(configPath).config;
       LocalGitRunner = foam.lookup('org.chromium.webidl.LocalGitRunner');
       Parser = config.parserClass;
-
+      
       var AccumulatorBox = foam.lookup('org.chromium.webidl.test.AccumulatorBox');
       outputBox = AccumulatorBox.create();
       errorBox = AccumulatorBox.create();
@@ -59,6 +59,7 @@ global.manualFetchAndParseTest = function(configPath, description) {
 
     it('should fetch git repo and send files to outputBox', function(done) {
       var onDone = function() {
+        console.log(`Found ${outputBox.results.length} results`);
         expect(outputBox.results.length > 0).toBe(true);
         expect(errorBox.results.length).toBe(0);
         done();

--- a/test/node/require-helper.js
+++ b/test/node/require-helper.js
@@ -13,10 +13,5 @@ beforeAll(function() {
   var rootDir = path.resolve(__dirname, '..', '..');
 
   // Load files into global.WEB_IDL_DIFF_FILES.
-  require(path.resolve(rootDir, 'config', 'files.js'));
-
-  var files = global.WEB_IDL_DIFF_FILES.slice();
-  for (var i = 0; i < files.length; i++) {
-    require(path.resolve(rootDir, files[i]));
-  }
+  require(path.resolve(rootDir, 'config', 'load_deps.js'));
 });


### PR DESCRIPTION
Fixes #102. See `lib/org/chromium/webidl/Parser.js` for the actual change; the rest is just to test it.

A (failing) test was written first; split the 'file iteration' step out from LocalGitRunner into a re-usable class, and uses it to iterate the `test/any/parsing/data/` dir and check the contents parse.

Then tweaked the grammar to match the spec; now it passes.

Also moved the 'iterate all the dep files and require them' into a `load_deps.js` helper.
