### PR TITLE
Fix IDLFragmentExtractor: Exclude <pre class="[excluded class]">

### DIFF
--- a/lib/org/chromium/webidl/IDLFragmentExtractor.js
+++ b/lib/org/chromium/webidl/IDLFragmentExtractor.js
@@ -79,6 +79,7 @@ foam.CLASS({
             cls = cls.concat(attr.value.split(' '));
           }
         });
+
         return cls.includes('example') || cls.includes('note');
       },
     },
@@ -99,12 +100,12 @@ foam.CLASS({
           this.tagStack_.pop();
         }
 
+        this.tagStack_.push(tag);
         if (this.tagStack_.excludedTop === null && tag.nodeName === 'pre' && isIDL) {
           // Found a <pre class="idl.*">.
           // Ignore tags and only extract text now.
           this.tagMatching_ = false;
         }
-        this.tagStack_.push(tag);
       },
     },
     {
@@ -217,4 +218,3 @@ foam.CLASS({
     },
   ],
 });
-

--- a/test/node/parsing/IDLFragmentExtractor-test.js
+++ b/test/node/parsing/IDLFragmentExtractor-test.js
@@ -63,6 +63,33 @@ describe('IDLFragmentExtractor', function() {
     expect(results[0]).toBe(idl);
   });
 
+  it('should exclude pre classes with exclusion CSS classes', function() {
+    var html1 = `<pre class="example idl">
+      interface Potato {
+        attribute unsigned long weight;
+      };
+    </pre>`;
+    var file1 = HTMLFileContents.create({
+      url: 'http://something.url',
+      timestamp: new Date(),
+      contents: html1,
+    });
+    var results1 = IDLFragmentExtractor.create().extract(file1);
+    expect(results1.length).toBe(0);
+    var html2 = `<pre class="idl note">
+      interface Tomato {
+        attribute unsigned long weight;
+      };
+    </pre>`;
+    var file2 = HTMLFileContents.create({
+      url: 'http://something.url',
+      timestamp: new Date(),
+      contents: html1,
+    });
+    var results2 = IDLFragmentExtractor.create().extract(file2);
+    expect(results2.length).toBe(0);
+  });
+
   it('should parse a HTML file with nested excludes', function() {
     var firstIDL = `
       interface Potato {


### PR DESCRIPTION
Order of operations for excluded tag management was excluding `<pre>` contents for:

```html
<foo class="[excluded class]">...<pre class="idl">...</pre>...</foo>
```

but not for:

```html
<pre class="[excluded class] idl">...</pre>
```